### PR TITLE
Add method assertion support

### DIFF
--- a/app/src/test/java/com/jorgecastillo/hiroaki/GsonNewsNetworkDataSourceTest.kt
+++ b/app/src/test/java/com/jorgecastillo/hiroaki/GsonNewsNetworkDataSourceTest.kt
@@ -49,7 +49,8 @@ class GsonNewsNetworkDataSourceTest {
                         "apiKey" to "a7c816f57c004c49a21bd458e11e2807"),
                 headers = mapOf(
                         "Cache-Control" to "max-age=640000"
-                ))
+                ),
+                method = "GET")
     }
 
     @Test
@@ -61,7 +62,8 @@ class GsonNewsNetworkDataSourceTest {
 
         server.assertRequest(
                 sentToPath = "v2/top-headlines",
-                jsonBodyResFile = "PublishHeadline.json" withType MoshiArticleDto::class.java)
+                jsonBodyResFile = "PublishHeadline.json" withType MoshiArticleDto::class.java,
+                method = "POST")
     }
 
     @Test

--- a/app/src/test/java/com/jorgecastillo/hiroaki/JacksonNewsNetworkDataSourceTest.kt
+++ b/app/src/test/java/com/jorgecastillo/hiroaki/JacksonNewsNetworkDataSourceTest.kt
@@ -49,7 +49,8 @@ class JacksonNewsNetworkDataSourceTest {
                         "apiKey" to "a7c816f57c004c49a21bd458e11e2807"),
                 headers = mapOf(
                         "Cache-Control" to "max-age=640000"
-                ))
+                ),
+                method = "GET")
     }
 
     @Test
@@ -61,7 +62,8 @@ class JacksonNewsNetworkDataSourceTest {
 
         server.assertRequest(
                 sentToPath = "v2/top-headlines",
-                jsonBodyResFile = "PublishHeadline.json" withType MoshiArticleDto::class.java)
+                jsonBodyResFile = "PublishHeadline.json" withType MoshiArticleDto::class.java,
+                method = "POST")
     }
 
     @Test

--- a/app/src/test/java/com/jorgecastillo/hiroaki/MoshiNewsNetworkDataSourceTest.kt
+++ b/app/src/test/java/com/jorgecastillo/hiroaki/MoshiNewsNetworkDataSourceTest.kt
@@ -49,7 +49,8 @@ class MoshiNewsNetworkDataSourceTest {
                         "apiKey" to "a7c816f57c004c49a21bd458e11e2807"),
                 headers = mapOf(
                         "Cache-Control" to "max-age=640000"
-                ))
+                ),
+                method = "GET")
     }
 
     @Test
@@ -61,7 +62,8 @@ class MoshiNewsNetworkDataSourceTest {
 
         server.assertRequest(
                 sentToPath = "v2/top-headlines",
-                jsonBodyResFile = "PublishHeadline.json" withType MoshiArticleDto::class.java)
+                jsonBodyResFile = "PublishHeadline.json" withType MoshiArticleDto::class.java,
+                method = "POST")
     }
 
     @Test

--- a/hiroaki/src/main/java/com/jorgecastillo/hiroaki/ServerExtensions.kt
+++ b/hiroaki/src/main/java/com/jorgecastillo/hiroaki/ServerExtensions.kt
@@ -2,13 +2,14 @@ package com.jorgecastillo.hiroaki
 
 import com.jorgecastillo.hiroaki.matchers.hasBody
 import com.jorgecastillo.hiroaki.matchers.hasHeaders
+import com.jorgecastillo.hiroaki.matchers.hasMethod
 import com.jorgecastillo.hiroaki.matchers.hasQueryParams
 import okhttp3.OkHttpClient
 import okhttp3.logging.HttpLoggingInterceptor
 import okhttp3.mockwebserver.MockResponse
 import okhttp3.mockwebserver.MockWebServer
 import org.hamcrest.CoreMatchers
-import org.hamcrest.MatcherAssert
+import org.hamcrest.MatcherAssert.assertThat
 import retrofit2.Converter
 import retrofit2.Retrofit
 
@@ -80,34 +81,39 @@ fun MockWebServer.assertRequest(
     queryParams: Map<String, String>? = null,
     jsonBodyResFile: Pair<String, Class<*>>? = null,
     jsonBody: Pair<String, Class<*>>? = null,
-    headers: Map<String, String>? = null
+    headers: Map<String, String>? = null,
+    method: String? = null
 ) {
     throwIfBothBodyParamsArePassed(jsonBodyResFile, jsonBody)
 
     val request = this.takeRequest()
-    MatcherAssert.assertThat(request.path, CoreMatchers.startsWith("/$sentToPath"))
+    assertThat(request.path, CoreMatchers.startsWith("/$sentToPath"))
 
     queryParams?.let {
-        MatcherAssert.assertThat(request, hasQueryParams(it))
+        assertThat(request, hasQueryParams(it))
     }
 
     jsonBodyResFile?.let {
         val fileStringBody = fileContentAsString(it.first)
-        MatcherAssert.assertThat(request, hasBody(
+        assertThat(request, hasBody(
                 fileStringBody,
                 fileStringBody.fromJson(it.second),
                 request.parse(it.second)))
     }
 
     jsonBody?.let {
-        MatcherAssert.assertThat(request, hasBody(
+        assertThat(request, hasBody(
                 it.first,
                 it.first.fromJson(it.second),
                 request.parse(it.second)))
     }
 
     headers?.let {
-        MatcherAssert.assertThat(request, hasHeaders(it))
+        assertThat(request, hasHeaders(it))
+    }
+
+    method?.let {
+        assertThat(request, hasMethod(method))
     }
 }
 

--- a/hiroaki/src/main/java/com/jorgecastillo/hiroaki/matchers/HasMethodMatcher.kt
+++ b/hiroaki/src/main/java/com/jorgecastillo/hiroaki/matchers/HasMethodMatcher.kt
@@ -1,0 +1,26 @@
+package com.jorgecastillo.hiroaki.matchers
+
+import okhttp3.mockwebserver.RecordedRequest
+import org.hamcrest.Description
+import org.hamcrest.Matcher
+import org.hamcrest.TypeSafeMatcher
+
+/**
+ * Custom Hamcrest matcher to assert about HTTP method (GET, POST, PUT, DELETE...) on an OkHttp
+ * RecordedRequest.
+ */
+fun hasMethod(expectedMethod: String): Matcher<RecordedRequest> {
+    return object : TypeSafeMatcher<RecordedRequest>() {
+
+        override fun describeTo(description: Description) {
+            description.appendText("The HTTP query should have method: $expectedMethod")
+        }
+
+        override fun describeMismatchSafely(request: RecordedRequest, mismatchDescription: Description) {
+            mismatchDescription.appendText("\nMethod ${request.method} was found instead.")
+        }
+
+        override fun matchesSafely(request: RecordedRequest): Boolean =
+                request.method == expectedMethod
+    }
+}


### PR DESCRIPTION
### :pushpin: References
**Issues:**
* Fixes #6 

### :tophat: What is the goal?

* Add support for HTTP method (GET, PUT, DELETE, UPDATE, POST, PATCH... etc) assertion.

### 💻 How is it being implemented?

* Added new optional parameter to `assertRequest` to assert over the http method sent on the request.

### 📱 How to Test

* Let the tests pass on CI.