### PR TITLE
Add eq assertion for expected results

### DIFF
--- a/app/src/test/java/com/jorgecastillo/hiroaki/GsonNewsNetworkDataSourceTest.kt
+++ b/app/src/test/java/com/jorgecastillo/hiroaki/GsonNewsNetworkDataSourceTest.kt
@@ -4,13 +4,12 @@ import com.jorgecastillo.hiroaki.data.datasource.GsonNewsNetworkDataSource
 import com.jorgecastillo.hiroaki.data.networkdto.MoshiArticleDto
 import com.jorgecastillo.hiroaki.data.service.GsonNewsApiService
 import com.jorgecastillo.hiroaki.model.Article
+import com.jorgecastillo.hiroaki.model.Source
 import com.jorgecastillo.hiroaki.models.fileBody
 import com.jorgecastillo.hiroaki.models.inlineBody
 import com.jorgecastillo.hiroaki.mother.anyArticle
 import kotlinx.coroutines.experimental.runBlocking
 import okhttp3.mockwebserver.MockWebServer
-import org.hamcrest.CoreMatchers.`is`
-import org.hamcrest.MatcherAssert.assertThat
 import org.junit.After
 import org.junit.Before
 import org.junit.Test
@@ -109,7 +108,7 @@ class GsonNewsNetworkDataSourceTest {
 
         val news = runBlocking { dataSource.getNews() }
 
-        thenNewsAreParsed(news)
+        news eq expectedNews()
     }
 
     @Test(expected = IOException::class)
@@ -119,7 +118,26 @@ class GsonNewsNetworkDataSourceTest {
         runBlocking { dataSource.getNews() }
     }
 
-    private fun thenNewsAreParsed(news: List<Article>) {
-        assertThat(news.size, `is`(3))
+    private fun expectedNews(): List<Article> {
+        return listOf(
+                Article("How to Get Android P's Screenshot Editing Tool on Any Android Phone",
+                        "Last year, Apple brought advanced screenshot editing tools to the iPhone with iOS 11, and, this week, Google fired back with a similar Android feature called Markup. The only catch is that this new tool is limited to Android P, which launches later this year …",
+                        "https://lifehacker.com/how-to-get-android-ps-screenshot-editing-tool-on-any-an-1823646122",
+                        "https://i.kinja-img.com/gawker-media/image/upload/s--Y-5X_NcT--/c_fill,fl_progressive,g_center,h_450,q_80,w_800/nxmwbkwzoc1z1tmak7s4.jpg",
+                        "2018-03-09T20:30:00Z",
+                        Source(null, "Lifehacker.com")),
+                Article("Capital One's virtual credit cards could help you avoid fraud",
+                        "Capital One is no stranger to trying new things -- especially when it comes to technology. Its Eno texting chatbot, for example, is a quick and conversational way for its customers to check their balances and perform simple tasks, like checking on recent tran…",
+                        "https://www.engadget.com/2018/03/09/capital-one-virtual-credit-cards/",
+                        "https://o.aolcdn.com/images/dims?thumbnail=1200%2C630&quality=80&image_uri=https%3A%2F%2Fo.aolcdn.com%2Fimages%2Fdims%3Fcrop%3D3861%252C2574%252C0%252C0%26quality%3D85%26format%3Djpg%26resize%3D1600%252C1067%26image_uri%3Dhttp%253A%252F%252Fo.aolcdn.com%252Fhss%252Fstorage%252Fmidas%252Fca9d74d8d57677d4f3291ae4347b26da%252F206197048%252Fcapital-one-financial-corp-signage-is-displayed-at-a-bank-branch-in-picture-id120933061%26client%3Da1acac3e1b3290917d92%26signature%3Db51d9958f8487452f6a8c6d354650fcb339f0520&client=cbc79c14efcebee57402&signature=44e59feb505c1b9c4e5867d453d3ed345010acac",
+                        "2018-03-09T13:00:00Z",
+                        Source("engadget", "Engadget")),
+                Article("Magic Leap gets \$461M more, Travis goes VC, and HQ Trivia scales up",
+                        "Hello and welcome back to Equity, TechCrunch’s venture capital-focused podcast where we unpack the numbers behind the headlines. This week we had a corking set of news to get through, so we rounded up the usual gang (Matthew Lynley, Katie Roof, and myself), a…",
+                        "http://techcrunch.com/2018/03/09/magic-leap-gets-461m-more-travis-goes-vc-and-hq-trivia-scales-up/",
+                        "https://tctechcrunch2011.files.wordpress.com/2017/03/tc-equity-podcast-ios.jpg",
+                        "2018-03-09T14:10:01Z",
+                        Source("techcrunch", "TechCrunch"))
+        )
     }
 }

--- a/app/src/test/java/com/jorgecastillo/hiroaki/JacksonNewsNetworkDataSourceTest.kt
+++ b/app/src/test/java/com/jorgecastillo/hiroaki/JacksonNewsNetworkDataSourceTest.kt
@@ -4,13 +4,12 @@ import com.jorgecastillo.hiroaki.data.datasource.JacksonNewsNetworkDataSource
 import com.jorgecastillo.hiroaki.data.networkdto.MoshiArticleDto
 import com.jorgecastillo.hiroaki.data.service.JacksonNewsApiService
 import com.jorgecastillo.hiroaki.model.Article
+import com.jorgecastillo.hiroaki.model.Source
 import com.jorgecastillo.hiroaki.models.fileBody
 import com.jorgecastillo.hiroaki.models.inlineBody
 import com.jorgecastillo.hiroaki.mother.anyArticle
 import kotlinx.coroutines.experimental.runBlocking
 import okhttp3.mockwebserver.MockWebServer
-import org.hamcrest.CoreMatchers.`is`
-import org.hamcrest.MatcherAssert.assertThat
 import org.junit.After
 import org.junit.Before
 import org.junit.Test
@@ -109,7 +108,7 @@ class JacksonNewsNetworkDataSourceTest {
 
         val news = runBlocking { dataSource.getNews() }
 
-        thenNewsAreParsed(news)
+        news eq expectedNews()
     }
 
     @Test(expected = IOException::class)
@@ -119,7 +118,26 @@ class JacksonNewsNetworkDataSourceTest {
         runBlocking { dataSource.getNews() }
     }
 
-    private fun thenNewsAreParsed(news: List<Article>) {
-        assertThat(news.size, `is`(3))
+    private fun expectedNews(): List<Article> {
+        return listOf(
+                Article("How to Get Android P's Screenshot Editing Tool on Any Android Phone",
+                        "Last year, Apple brought advanced screenshot editing tools to the iPhone with iOS 11, and, this week, Google fired back with a similar Android feature called Markup. The only catch is that this new tool is limited to Android P, which launches later this year …",
+                        "https://lifehacker.com/how-to-get-android-ps-screenshot-editing-tool-on-any-an-1823646122",
+                        "https://i.kinja-img.com/gawker-media/image/upload/s--Y-5X_NcT--/c_fill,fl_progressive,g_center,h_450,q_80,w_800/nxmwbkwzoc1z1tmak7s4.jpg",
+                        "2018-03-09T20:30:00Z",
+                        Source(null, "Lifehacker.com")),
+                Article("Capital One's virtual credit cards could help you avoid fraud",
+                        "Capital One is no stranger to trying new things -- especially when it comes to technology. Its Eno texting chatbot, for example, is a quick and conversational way for its customers to check their balances and perform simple tasks, like checking on recent tran…",
+                        "https://www.engadget.com/2018/03/09/capital-one-virtual-credit-cards/",
+                        "https://o.aolcdn.com/images/dims?thumbnail=1200%2C630&quality=80&image_uri=https%3A%2F%2Fo.aolcdn.com%2Fimages%2Fdims%3Fcrop%3D3861%252C2574%252C0%252C0%26quality%3D85%26format%3Djpg%26resize%3D1600%252C1067%26image_uri%3Dhttp%253A%252F%252Fo.aolcdn.com%252Fhss%252Fstorage%252Fmidas%252Fca9d74d8d57677d4f3291ae4347b26da%252F206197048%252Fcapital-one-financial-corp-signage-is-displayed-at-a-bank-branch-in-picture-id120933061%26client%3Da1acac3e1b3290917d92%26signature%3Db51d9958f8487452f6a8c6d354650fcb339f0520&client=cbc79c14efcebee57402&signature=44e59feb505c1b9c4e5867d453d3ed345010acac",
+                        "2018-03-09T13:00:00Z",
+                        Source("engadget", "Engadget")),
+                Article("Magic Leap gets \$461M more, Travis goes VC, and HQ Trivia scales up",
+                        "Hello and welcome back to Equity, TechCrunch’s venture capital-focused podcast where we unpack the numbers behind the headlines. This week we had a corking set of news to get through, so we rounded up the usual gang (Matthew Lynley, Katie Roof, and myself), a…",
+                        "http://techcrunch.com/2018/03/09/magic-leap-gets-461m-more-travis-goes-vc-and-hq-trivia-scales-up/",
+                        "https://tctechcrunch2011.files.wordpress.com/2017/03/tc-equity-podcast-ios.jpg",
+                        "2018-03-09T14:10:01Z",
+                        Source("techcrunch", "TechCrunch"))
+        )
     }
 }

--- a/app/src/test/java/com/jorgecastillo/hiroaki/MoshiNewsNetworkDataSourceTest.kt
+++ b/app/src/test/java/com/jorgecastillo/hiroaki/MoshiNewsNetworkDataSourceTest.kt
@@ -4,13 +4,12 @@ import com.jorgecastillo.hiroaki.data.datasource.MoshiNewsNetworkDataSource
 import com.jorgecastillo.hiroaki.data.networkdto.MoshiArticleDto
 import com.jorgecastillo.hiroaki.data.service.MoshiNewsApiService
 import com.jorgecastillo.hiroaki.model.Article
+import com.jorgecastillo.hiroaki.model.Source
 import com.jorgecastillo.hiroaki.models.fileBody
 import com.jorgecastillo.hiroaki.models.inlineBody
 import com.jorgecastillo.hiroaki.mother.anyArticle
 import kotlinx.coroutines.experimental.runBlocking
 import okhttp3.mockwebserver.MockWebServer
-import org.hamcrest.CoreMatchers.`is`
-import org.hamcrest.MatcherAssert.assertThat
 import org.junit.After
 import org.junit.Before
 import org.junit.Test
@@ -109,7 +108,7 @@ class MoshiNewsNetworkDataSourceTest {
 
         val news = runBlocking { dataSource.getNews() }
 
-        thenNewsAreParsed(news)
+        news eq expectedNews()
     }
 
     @Test(expected = IOException::class)
@@ -119,7 +118,26 @@ class MoshiNewsNetworkDataSourceTest {
         runBlocking { dataSource.getNews() }
     }
 
-    private fun thenNewsAreParsed(news: List<Article>) {
-        assertThat(news.size, `is`(3))
+    private fun expectedNews(): List<Article> {
+        return listOf(
+                Article("How to Get Android P's Screenshot Editing Tool on Any Android Phone",
+                        "Last year, Apple brought advanced screenshot editing tools to the iPhone with iOS 11, and, this week, Google fired back with a similar Android feature called Markup. The only catch is that this new tool is limited to Android P, which launches later this year …",
+                        "https://lifehacker.com/how-to-get-android-ps-screenshot-editing-tool-on-any-an-1823646122",
+                        "https://i.kinja-img.com/gawker-media/image/upload/s--Y-5X_NcT--/c_fill,fl_progressive,g_center,h_450,q_80,w_800/nxmwbkwzoc1z1tmak7s4.jpg",
+                        "2018-03-09T20:30:00Z",
+                        Source(null, "Lifehacker.com")),
+                Article("Capital One's virtual credit cards could help you avoid fraud",
+                        "Capital One is no stranger to trying new things -- especially when it comes to technology. Its Eno texting chatbot, for example, is a quick and conversational way for its customers to check their balances and perform simple tasks, like checking on recent tran…",
+                        "https://www.engadget.com/2018/03/09/capital-one-virtual-credit-cards/",
+                        "https://o.aolcdn.com/images/dims?thumbnail=1200%2C630&quality=80&image_uri=https%3A%2F%2Fo.aolcdn.com%2Fimages%2Fdims%3Fcrop%3D3861%252C2574%252C0%252C0%26quality%3D85%26format%3Djpg%26resize%3D1600%252C1067%26image_uri%3Dhttp%253A%252F%252Fo.aolcdn.com%252Fhss%252Fstorage%252Fmidas%252Fca9d74d8d57677d4f3291ae4347b26da%252F206197048%252Fcapital-one-financial-corp-signage-is-displayed-at-a-bank-branch-in-picture-id120933061%26client%3Da1acac3e1b3290917d92%26signature%3Db51d9958f8487452f6a8c6d354650fcb339f0520&client=cbc79c14efcebee57402&signature=44e59feb505c1b9c4e5867d453d3ed345010acac",
+                        "2018-03-09T13:00:00Z",
+                        Source("engadget", "Engadget")),
+                Article("Magic Leap gets \$461M more, Travis goes VC, and HQ Trivia scales up",
+                        "Hello and welcome back to Equity, TechCrunch’s venture capital-focused podcast where we unpack the numbers behind the headlines. This week we had a corking set of news to get through, so we rounded up the usual gang (Matthew Lynley, Katie Roof, and myself), a…",
+                        "http://techcrunch.com/2018/03/09/magic-leap-gets-461m-more-travis-goes-vc-and-hq-trivia-scales-up/",
+                        "https://tctechcrunch2011.files.wordpress.com/2017/03/tc-equity-podcast-ios.jpg",
+                        "2018-03-09T14:10:01Z",
+                        Source("techcrunch", "TechCrunch"))
+        )
     }
 }

--- a/hiroaki/src/main/java/com/jorgecastillo/hiroaki/Assertions.kt
+++ b/hiroaki/src/main/java/com/jorgecastillo/hiroaki/Assertions.kt
@@ -1,0 +1,67 @@
+package com.jorgecastillo.hiroaki
+
+import com.jorgecastillo.hiroaki.matchers.hasBody
+import com.jorgecastillo.hiroaki.matchers.hasHeaders
+import com.jorgecastillo.hiroaki.matchers.hasMethod
+import com.jorgecastillo.hiroaki.matchers.hasQueryParams
+import com.jorgecastillo.hiroaki.models.JsonBody
+import com.jorgecastillo.hiroaki.models.JsonBodyFile
+import okhttp3.mockwebserver.MockWebServer
+import org.hamcrest.CoreMatchers
+import org.hamcrest.CoreMatchers.`is`
+import org.hamcrest.MatcherAssert
+import org.hamcrest.MatcherAssert.assertThat
+
+fun MockWebServer.assertRequest(
+    sentToPath: String,
+    queryParams: QueryParams? = null,
+    jsonBodyResFile: JsonBodyFile? = null,
+    jsonBody: JsonBody? = null,
+    headers: Headers? = null,
+    method: String? = null
+) {
+    throwIfBothBodyParamsArePassed(jsonBodyResFile, jsonBody)
+
+    val request = this.takeRequest()
+    MatcherAssert.assertThat(request.path, CoreMatchers.startsWith("/$sentToPath"))
+
+    queryParams?.let {
+        MatcherAssert.assertThat(request, hasQueryParams(it))
+    }
+
+    jsonBodyResFile?.let {
+        val fileStringBody = fileContentAsString(it.jsonBodyResFile)
+        MatcherAssert.assertThat(request, hasBody(
+                fileStringBody,
+                fileStringBody.fromJson(it.type),
+                request.parse(it.type)))
+    }
+
+    jsonBody?.let {
+        MatcherAssert.assertThat(request, hasBody(
+                it.jsonBody,
+                it.jsonBody.fromJson(it.type),
+                request.parse(it.type)))
+    }
+
+    headers?.let {
+        MatcherAssert.assertThat(request, hasHeaders(it))
+    }
+
+    method?.let {
+        MatcherAssert.assertThat(request, hasMethod(method))
+    }
+}
+
+private fun throwIfBothBodyParamsArePassed(
+    jsonBodyResFile: JsonBodyFile? = null,
+    jsonBody: JsonBody? = null
+) {
+    if (jsonBodyResFile != null && jsonBody != null) {
+        throw IllegalArgumentException("Please pass jsonBodyFile name or jsonBody, but not both.")
+    }
+}
+
+infix fun <T> T.eq(other: T) {
+    assertThat(this, `is`(other))
+}


### PR DESCRIPTION
### :pushpin: References
**Issues:**
* Fixes #11 

### :tophat: What is the goal?

* We want to support asserting that the parsed objects by our API clients or network data sources are matching a expected data class / class format.

### 💻 How is it being implemented?

* That just means we should be able to easily assert that `parsedResult == expectedResult` to it's more like using the already existent `is` operator. But I'm adding an `eq` infix operation that allows you to perform an assertion for tests like: `news eq expectedNews()`
* Added the optional possibility to pass a custom `OkHttpClient` to the retrofitEndpoint builder just in case you're not okay with the default one. 
* Moved the `MockWebServer` assertions to a separated file for organizational purposes.

### 🖼  Screenshots or Gifs

<img width="1241" alt="captura de pantalla 2018-03-13 a las 15 51 59" src="https://user-images.githubusercontent.com/6547526/37349497-d9d3ea30-26d6-11e8-82cb-2d002d4014d2.png">

### 📱 How to Test

* Let CI test pass.