### PR TITLE
Add base class for server boilerplate

### DIFF
--- a/app/src/test/java/com/jorgecastillo/hiroaki/GsonNewsNetworkDataSourceTest.kt
+++ b/app/src/test/java/com/jorgecastillo/hiroaki/GsonNewsNetworkDataSourceTest.kt
@@ -9,8 +9,6 @@ import com.jorgecastillo.hiroaki.models.fileBody
 import com.jorgecastillo.hiroaki.models.inlineBody
 import com.jorgecastillo.hiroaki.mother.anyArticle
 import kotlinx.coroutines.experimental.runBlocking
-import okhttp3.mockwebserver.MockWebServer
-import org.junit.After
 import org.junit.Before
 import org.junit.Test
 import org.junit.runner.RunWith
@@ -19,22 +17,16 @@ import retrofit2.converter.gson.GsonConverterFactory
 import java.io.IOException
 
 @RunWith(MockitoJUnitRunner::class)
-class GsonNewsNetworkDataSourceTest {
+class GsonNewsNetworkDataSourceTest : MockServerSuite() {
 
     private lateinit var dataSource: GsonNewsNetworkDataSource
-    private lateinit var server: MockWebServer
 
     @Before
-    fun setup() {
-        server = MockWebServer()
+    override fun setup() {
+        super.setup()
         dataSource = GsonNewsNetworkDataSource(server.retrofitService(
                 GsonNewsApiService::class.java,
                 GsonConverterFactory.create()))
-    }
-
-    @After
-    fun tearDown() {
-        server.shutdown()
     }
 
     @Test

--- a/app/src/test/java/com/jorgecastillo/hiroaki/JacksonNewsNetworkDataSourceTest.kt
+++ b/app/src/test/java/com/jorgecastillo/hiroaki/JacksonNewsNetworkDataSourceTest.kt
@@ -9,8 +9,6 @@ import com.jorgecastillo.hiroaki.models.fileBody
 import com.jorgecastillo.hiroaki.models.inlineBody
 import com.jorgecastillo.hiroaki.mother.anyArticle
 import kotlinx.coroutines.experimental.runBlocking
-import okhttp3.mockwebserver.MockWebServer
-import org.junit.After
 import org.junit.Before
 import org.junit.Test
 import org.junit.runner.RunWith
@@ -19,22 +17,16 @@ import retrofit2.converter.jackson.JacksonConverterFactory
 import java.io.IOException
 
 @RunWith(MockitoJUnitRunner::class)
-class JacksonNewsNetworkDataSourceTest {
+class JacksonNewsNetworkDataSourceTest : MockServerSuite() {
 
     private lateinit var dataSource: JacksonNewsNetworkDataSource
-    private lateinit var server: MockWebServer
 
     @Before
-    fun setup() {
-        server = MockWebServer()
+    override fun setup() {
+        super.setup()
         dataSource = JacksonNewsNetworkDataSource(server.retrofitService(
                 JacksonNewsApiService::class.java,
                 JacksonConverterFactory.create()))
-    }
-
-    @After
-    fun tearDown() {
-        server.shutdown()
     }
 
     @Test

--- a/app/src/test/java/com/jorgecastillo/hiroaki/MoshiNewsNetworkDataSourceTest.kt
+++ b/app/src/test/java/com/jorgecastillo/hiroaki/MoshiNewsNetworkDataSourceTest.kt
@@ -9,8 +9,6 @@ import com.jorgecastillo.hiroaki.models.fileBody
 import com.jorgecastillo.hiroaki.models.inlineBody
 import com.jorgecastillo.hiroaki.mother.anyArticle
 import kotlinx.coroutines.experimental.runBlocking
-import okhttp3.mockwebserver.MockWebServer
-import org.junit.After
 import org.junit.Before
 import org.junit.Test
 import org.junit.runner.RunWith
@@ -19,22 +17,16 @@ import retrofit2.converter.moshi.MoshiConverterFactory
 import java.io.IOException
 
 @RunWith(MockitoJUnitRunner::class)
-class MoshiNewsNetworkDataSourceTest {
+class MoshiNewsNetworkDataSourceTest : MockServerSuite() {
 
     private lateinit var dataSource: MoshiNewsNetworkDataSource
-    private lateinit var server: MockWebServer
 
     @Before
-    fun setup() {
-        server = MockWebServer()
+    override fun setup() {
+        super.setup()
         dataSource = MoshiNewsNetworkDataSource(server.retrofitService(
                 MoshiNewsApiService::class.java,
                 MoshiConverterFactory.create()))
-    }
-
-    @After
-    fun tearDown() {
-        server.shutdown()
     }
 
     @Test

--- a/hiroaki/src/main/java/com/jorgecastillo/hiroaki/MockServerSuite.kt
+++ b/hiroaki/src/main/java/com/jorgecastillo/hiroaki/MockServerSuite.kt
@@ -1,0 +1,24 @@
+package com.jorgecastillo.hiroaki
+
+import okhttp3.mockwebserver.MockWebServer
+import org.junit.After
+import org.junit.Before
+
+/**
+ * Base class to provide the mock server before and after the test execution. Intentionally avoided
+ * using a rule for readability (not requiring tests to access server through the rule like
+ * rule.server.enqueue() but directly server.enqueue()).
+ */
+open class MockServerSuite {
+    lateinit var server: MockWebServer
+
+    @Before
+    open fun setup() {
+        server = MockWebServer()
+    }
+
+    @After
+    open fun tearDown() {
+        server.shutdown()
+    }
+}

--- a/hiroaki/src/main/java/com/jorgecastillo/hiroaki/ServerExtensions.kt
+++ b/hiroaki/src/main/java/com/jorgecastillo/hiroaki/ServerExtensions.kt
@@ -11,16 +11,16 @@ private const val SUCCESS_RESPONSE_CODE = 200
 private const val UNAUTHORIZED_RESPONSE_CODE = 401
 
 private fun okHttpClient(
-        loggingLevel: HttpLoggingInterceptor.Level = HttpLoggingInterceptor.Level.BODY
+    loggingLevel: HttpLoggingInterceptor.Level = HttpLoggingInterceptor.Level.BODY
 ): OkHttpClient =
         OkHttpClient.Builder()
                 .addInterceptor(HttpLoggingInterceptor().setLevel(loggingLevel))
                 .build()
 
 fun <T> MockWebServer.retrofitService(
-        serviceClass: Class<T>,
-        converterFactory: Converter.Factory,
-        okHttpClient: OkHttpClient = okHttpClient()
+    serviceClass: Class<T>,
+    converterFactory: Converter.Factory,
+    okHttpClient: OkHttpClient = okHttpClient()
 ): T {
     return Retrofit.Builder().baseUrl(this.url("/").toString())
             .client(okHttpClient)


### PR DESCRIPTION
### :pushpin: References
**Issues:**
* Fixes #5 

### :tophat: What is the goal?

* We would need to provide a base test class that users can extend and takes care of all the initialization / shutdown boilerplate for them.

### 💻 How is it being implemented?

* Added `MockServerSuite` base class so you don't need to take care of initializing or shutting down server by yourself. I you need to pass a custom server, you can always override the variable value on your `setup()` method override.

### 📱 How to Test

* Let tests pass on CI.
