### PR TITLE
Add docs for passing custom okhttp client

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,7 +40,7 @@ mock server url. To do that, you can wake up a **mock retrofit service** passing
 interface** and the **converter** you want to use. 
 
 Finally, you are free to pass this mocked service to your `ApiClient`, `NetworkDataSource`, or 
-however your collaborator using it is called.
+whatever your collaborator using it is called.
 
 Note that you'll also need to extend the base class `MockServerSuite`, which takes care of running 
 and shutting down the server for you.


### PR DESCRIPTION
### :pushpin: References
**Issues:**
* Fixes #15 

### :tophat: What is the goal?

* Sometimes you want to configure `OkHttpClient` by yourself to setup different / very specific configurations to match your needs. Add docs on how to do it.

### 💻 How is it being implemented?

* Added required docs to README.
