### PR TITLE
Remove the need to pass explicit QueueDispatcher

### DIFF
--- a/app/src/test/java/com/jorgecastillo/hiroaki/MockingRequestsTest.kt
+++ b/app/src/test/java/com/jorgecastillo/hiroaki/MockingRequestsTest.kt
@@ -9,7 +9,6 @@ import com.jorgecastillo.hiroaki.models.error
 import com.jorgecastillo.hiroaki.models.response
 import com.jorgecastillo.hiroaki.models.success
 import kotlinx.coroutines.experimental.runBlocking
-import okhttp3.mockwebserver.QueueDispatcher
 import org.junit.Before
 import org.junit.Test
 import org.junit.runner.RunWith
@@ -32,7 +31,6 @@ class MockingRequestsTest : MockServerSuite() {
 
     @Test
     fun enqueuesSuccess() {
-        server.setDispatcher(QueueDispatcher())
         server.enqueue(success(jsonFileName = "GetNews.json"))
 
         val news = runBlocking { dataSource.getNews() }
@@ -42,7 +40,6 @@ class MockingRequestsTest : MockServerSuite() {
 
     @Test(expected = IOException::class)
     fun enqueueError() {
-        server.setDispatcher(QueueDispatcher())
         server.enqueue(error())
 
         runBlocking { dataSource.getNews() }
@@ -50,7 +47,6 @@ class MockingRequestsTest : MockServerSuite() {
 
     @Test
     fun mockResponseSuccess() {
-        server.setDispatcher(QueueDispatcher())
         server.enqueue(response(200, jsonFileName = "GetNews.json"))
 
         val news = runBlocking { dataSource.getNews() }
@@ -60,7 +56,6 @@ class MockingRequestsTest : MockServerSuite() {
 
     @Test(expected = IOException::class)
     fun mockResponseError() {
-        server.setDispatcher(QueueDispatcher())
         server.enqueue(response(307))
 
         runBlocking { dataSource.getNews() }

--- a/hiroaki/src/main/java/com/jorgecastillo/hiroaki/ServerExtensions.kt
+++ b/hiroaki/src/main/java/com/jorgecastillo/hiroaki/ServerExtensions.kt
@@ -1,5 +1,6 @@
 package com.jorgecastillo.hiroaki
 
+import com.jorgecastillo.hiroaki.dispatcher.DispatcherRetainer
 import com.jorgecastillo.hiroaki.matchers.matches
 import com.jorgecastillo.hiroaki.models.JsonBody
 import com.jorgecastillo.hiroaki.models.JsonBodyFile
@@ -17,16 +18,16 @@ enum class Method {
 }
 
 private fun okHttpClient(
-        loggingLevel: HttpLoggingInterceptor.Level = HttpLoggingInterceptor.Level.BODY
+    loggingLevel: HttpLoggingInterceptor.Level = HttpLoggingInterceptor.Level.BODY
 ): OkHttpClient =
         OkHttpClient.Builder()
                 .addInterceptor(HttpLoggingInterceptor().setLevel(loggingLevel))
                 .build()
 
 fun <T> MockWebServer.retrofitService(
-        serviceClass: Class<T>,
-        converterFactory: Converter.Factory,
-        okHttpClient: OkHttpClient = okHttpClient()
+    serviceClass: Class<T>,
+    converterFactory: Converter.Factory,
+    okHttpClient: OkHttpClient = okHttpClient()
 ): T {
     return Retrofit.Builder().baseUrl(this.url("/").toString())
             .client(okHttpClient)
@@ -34,12 +35,15 @@ fun <T> MockWebServer.retrofitService(
             .create(serviceClass)
 }
 
-fun MockWebServer.whenever(sentToPath: String,
-                           queryParams: QueryParams? = null,
-                           jsonBodyResFile: JsonBodyFile? = null,
-                           jsonBody: JsonBody? = null,
-                           headers: Headers? = null,
-                           method: Method? = null): PotentialRequestChain {
+fun MockWebServer.whenever(
+    sentToPath: String,
+    queryParams: QueryParams? = null,
+    jsonBodyResFile: JsonBodyFile? = null,
+    jsonBody: JsonBody? = null,
+    headers: Headers? = null,
+    method: Method? = null
+): PotentialRequestChain {
+    this.setDispatcher(DispatcherRetainer.dispatcher)
     return PotentialRequestChain(matches(
             sentToPath = sentToPath,
             method = method,
@@ -50,12 +54,14 @@ fun MockWebServer.whenever(sentToPath: String,
 }
 
 fun MockWebServer.whenever(method: Method, sentToPath: String): PotentialRequestChain {
+    this.setDispatcher(DispatcherRetainer.dispatcher)
     return PotentialRequestChain(matches(
             method = method,
             sentToPath = sentToPath))
 }
 
 fun MockWebServer.whenever(method: Method, sentToPath: String, params: QueryParams): PotentialRequestChain {
+    this.setDispatcher(DispatcherRetainer.dispatcher)
     return PotentialRequestChain(matches(
             method = method,
             sentToPath = sentToPath,
@@ -63,6 +69,7 @@ fun MockWebServer.whenever(method: Method, sentToPath: String, params: QueryPara
 }
 
 fun MockWebServer.whenever(method: Method, sentToPath: String, jsonBody: JsonBody): PotentialRequestChain {
+    this.setDispatcher(DispatcherRetainer.dispatcher)
     return PotentialRequestChain(matches(
             method = method,
             sentToPath = sentToPath,
@@ -70,6 +77,7 @@ fun MockWebServer.whenever(method: Method, sentToPath: String, jsonBody: JsonBod
 }
 
 fun MockWebServer.whenever(method: Method, sentToPath: String, jsonBodyResFile: JsonBodyFile): PotentialRequestChain {
+    this.setDispatcher(DispatcherRetainer.dispatcher)
     return PotentialRequestChain(matches(
             method = method,
             sentToPath = sentToPath,
@@ -77,5 +85,6 @@ fun MockWebServer.whenever(method: Method, sentToPath: String, jsonBodyResFile: 
 }
 
 fun MockWebServer.whenever(matcher: Matcher<RecordedRequest>): PotentialRequestChain {
+    this.setDispatcher(DispatcherRetainer.dispatcher)
     return PotentialRequestChain(matcher)
 }

--- a/hiroaki/src/main/java/com/jorgecastillo/hiroaki/internal/MockServerRule.kt
+++ b/hiroaki/src/main/java/com/jorgecastillo/hiroaki/internal/MockServerRule.kt
@@ -2,6 +2,7 @@ package com.jorgecastillo.hiroaki.internal
 
 import com.jorgecastillo.hiroaki.dispatcher.DispatcherRetainer
 import okhttp3.mockwebserver.MockWebServer
+import okhttp3.mockwebserver.QueueDispatcher
 import org.junit.Before
 import org.junit.rules.ExternalResource
 
@@ -14,11 +15,11 @@ class MockServerRule : ExternalResource() {
         super.before()
         server = MockWebServer()
         DispatcherRetainer.dispatcher.reset()
-        server.setDispatcher(DispatcherRetainer.dispatcher)
     }
 
     override fun after() {
         super.after()
         DispatcherRetainer.dispatcher.reset()
+        server.setDispatcher(QueueDispatcher())
     }
 }

--- a/hiroaki/src/main/java/com/jorgecastillo/hiroaki/internal/MockServerSuite.kt
+++ b/hiroaki/src/main/java/com/jorgecastillo/hiroaki/internal/MockServerSuite.kt
@@ -2,6 +2,7 @@ package com.jorgecastillo.hiroaki.internal
 
 import com.jorgecastillo.hiroaki.dispatcher.DispatcherRetainer
 import okhttp3.mockwebserver.MockWebServer
+import okhttp3.mockwebserver.QueueDispatcher
 import org.junit.After
 import org.junit.Before
 
@@ -17,12 +18,12 @@ open class MockServerSuite {
     open fun setup() {
         server = MockWebServer()
         DispatcherRetainer.dispatcher.reset()
-        server.setDispatcher(DispatcherRetainer.dispatcher)
     }
 
     @After
     open fun tearDown() {
         server.shutdown()
         DispatcherRetainer.dispatcher.reset()
+        server.setDispatcher(QueueDispatcher())
     }
 }


### PR DESCRIPTION
### :pushpin: References
**Issues:**
* Fixes #34

### :tophat: What is the goal?

* Remove the need for passing an explicit `QueueDispatcher` if you want to enqueue standard `MockResponses` on the `MockWebServer`.

### 💻 How is it being implemented?

* By default, the server is configured with a `QueueDispatcher`.
* `HiroakiDispatcher` is just set when you call `whenever()`, but it's still a singleton.
* The `QueueDispatcher` is restored after each test to reset the testing environment.

### 📱 How to Test

* Let the tests pass on CircleCI.