### PR TITLE
Add docs on how to use Hiroaki just with OkHttp to readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -114,6 +114,9 @@ class RuleNetworkDataSourceTest {
     }
 }
 ```
+
+**Using Hiroaki without Retrofit (just OkHttp)**
+
 If you're not using `Retrofit` but just [OkHttp](http://square.github.io/okhttp/) you can still use **Hiroaki**. Just 
 request the URL from the mock server provided by the base class or the rule, and pass it to your collaborator to create your OkHttp requests.
 ````kotlin


### PR DESCRIPTION
### :pushpin: References
**Issues:**
* Fixes #43 

### :tophat: What is the goal?

* We want to add docs about how to use **Hiroaki** without `Retrofit` and just with OkHttp.

### 💻 How is it being implemented?

* Added the required docs to README.

### 📱 How to Test

* Let tests pass on CI.