### PR TITLE
Fix dependencies

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,8 +20,8 @@ Add the following code to your ``build.gradle``. Both dependencies are available
 
 ```groovy
 dependencies{
-    implementation 'me.jorgecastillo:hiroaki-core:0.0.4'
-    implementation 'me.jorgecastillo:hiroaki-android:0.0.4' // Android instrumentation tests
+    testImplementation 'me.jorgecastillo:hiroaki-core:0.0.4'
+    androidTestImplementation 'me.jorgecastillo:hiroaki-android:0.0.4' // Android instrumentation tests
 }
 ```
 

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -42,8 +42,8 @@ dependencies {
     def supportVersion = "27.1.0"
     def retrofitVersion = "2.3.0"
 
-    implementation "me.jorgecastillo:hiroaki-core:0.0.4"
-    implementation "me.jorgecastillo:hiroaki-android:0.0.4"
+    testImplementation "me.jorgecastillo:hiroaki-core:0.0.4"
+    androidTestImplementation "me.jorgecastillo:hiroaki-android:0.0.4"
 
     // Kotlin
     implementation "org.jetbrains.kotlin:kotlin-stdlib-jre7:$kotlin_version"


### PR DESCRIPTION
### :tophat: What is the goal?

* Remove App's `hiroaki` dependencies and only use them into tests scopes

### 💻 How is it being implemented?

Change the `implementation` dependency configuration for `testImplementation` and `androidTestImplementation` according with the tests scope

Update the README to show the proper way to setup the dependencies into your project