### PR TITLE
Enable multiple query params with same key matching

### DIFF
--- a/README.md
+++ b/README.md
@@ -160,7 +160,7 @@ These are all the supported params for `whenever` that you can match to. All of 
 ```kotlin
 server.whenever(method = Method.GET,
                 sentToPath = "v2/top-headlines",
-                queryParams = mapOf("sources" to "crypto-coins-news",
+                queryParams = params("sources" to "crypto-coins-news",
                         "apiKey" to "a7c816f57c004c49a21bd458e11e2807"),
                 jsonBody = fileBody("GetNews.json"), // (file, inline, or JsonDSL)
                 headers = headers("Cache-Control" to "max-age=640000"))

--- a/app/src/test/java/me/jorgecastillo/hiroaki/MockingRequestsTest.kt
+++ b/app/src/test/java/me/jorgecastillo/hiroaki/MockingRequestsTest.kt
@@ -125,7 +125,7 @@ class MockingRequestsTest : MockServerSuite() {
         server.whenever(
                 method = Method.GET,
                 sentToPath = "v2/top-headlines",
-                queryParams = mapOf("sources" to "crypto-coins-news",
+                queryParams = params("sources" to "crypto-coins-news",
                         "apiKey" to "a7c816f57c004c49a21bd458e11e2807"))
                 .thenRespond(success(jsonBody = fileBody("GetNews.json")))
 
@@ -136,7 +136,7 @@ class MockingRequestsTest : MockServerSuite() {
 
     @Test(expected = IOException::class)
     fun failsWithUnknownParams() {
-        server.whenever(Method.GET, "v2/top-headlines", mapOf("randomParam" to "someValue"))
+        server.whenever(Method.GET, "v2/top-headlines", params("randomParam" to "someValue"))
                 .thenRespond(success(jsonBody = fileBody("GetNews.json")))
 
         runBlocking { dataSource.getNews() }

--- a/app/src/test/java/me/jorgecastillo/hiroaki/VerificationTest.kt
+++ b/app/src/test/java/me/jorgecastillo/hiroaki/VerificationTest.kt
@@ -1,0 +1,107 @@
+package me.jorgecastillo.hiroaki
+
+import me.jorgecastillo.hiroaki.internal.MockServerSuite
+import me.jorgecastillo.hiroaki.model.Article
+import me.jorgecastillo.hiroaki.model.Source
+import me.jorgecastillo.hiroaki.models.success
+import me.jorgecastillo.hiroaki.services.SomeService
+import org.junit.Before
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.mockito.junit.MockitoJUnitRunner
+import retrofit2.converter.gson.GsonConverterFactory
+
+@RunWith(MockitoJUnitRunner::class)
+class VerificationTest : MockServerSuite() {
+
+    private lateinit var service: SomeService
+
+    @Before
+    override fun setup() {
+        super.setup()
+        service = server.retrofitService(
+                SomeService::class.java,
+                GsonConverterFactory.create()
+        )
+    }
+
+    @Test
+    fun matchesQueryParamsLists() {
+        server.whenever(Method.POST, "my-fake-service/edit-tag")
+                .thenRespond(success())
+
+        service.addNewsTags(listOf("1", "2", "3"), listOf("some-tag-1", "some-tag-2", "some-tag-3"))
+                .execute()
+
+        server.verify("my-fake-service/edit-tag").called(
+                times = once(),
+                queryParams = params(
+                        "i" to "1",
+                        "i" to "2",
+                        "i" to "3",
+                        "a" to "some-tag-1",
+                        "a" to "some-tag-2",
+                        "a" to "some-tag-3"))
+    }
+
+    @Test
+    fun matchesQueryParamsList() {
+        server.whenever(Method.POST, "my-fake-service/edit-tag")
+                .thenRespond(success())
+
+        service.addNewsTags(listOf("1", "2", "3"), listOf("some-tag-1", "some-tag-2", "some-tag-3"))
+                .execute()
+
+        server.verify("my-fake-service/edit-tag").called(
+                times = once(),
+                queryParams = params(
+                        "a" to "some-tag-1",
+                        "a" to "some-tag-2",
+                        "a" to "some-tag-3"))
+    }
+
+    @Test(expected = AssertionError::class)
+    fun failsQueryParamListWithWrongValue() {
+        server.whenever(Method.POST, "my-fake-service/edit-tag")
+                .thenRespond(success())
+
+        service.addNewsTags(listOf("1", "2", "3"), listOf("some-tag-1", "some-tag-2", "some-tag-3"))
+                .execute()
+
+        server.verify("my-fake-service/edit-tag").called(
+                times = once(),
+                queryParams = params(
+                        "a" to "some-tag-1",
+                        "a" to "some-tag-6-fail",
+                        "a" to "some-tag-3"))
+    }
+
+    private fun expectedNews(): List<Article> {
+        return listOf(
+                Article(
+                        "How to Get Android P's Screenshot Editing Tool on Any Android Phone",
+                        "Last year, Apple brought advanced screenshot editing tools to the iPhone with iOS 11, and, this week, Google fired back with a similar Android feature called Markup. The only catch is that this new tool is limited to Android P, which launches later this year …",
+                        "https://lifehacker.com/how-to-get-android-ps-screenshot-editing-tool-on-any-an-1823646122",
+                        "https://i.kinja-img.com/gawker-media/image/upload/s--Y-5X_NcT--/c_fill,fl_progressive,g_center,h_450,q_80,w_800/nxmwbkwzoc1z1tmak7s4.jpg",
+                        "2018-03-09T20:30:00Z",
+                        Source(null, "Lifehacker.com")
+                ),
+                Article(
+                        "Capital One's virtual credit cards could help you avoid fraud",
+                        "Capital One is no stranger to trying new things -- especially when it comes to technology. Its Eno texting chatbot, for example, is a quick and conversational way for its customers to check their balances and perform simple tasks, like checking on recent tran…",
+                        "https://www.engadget.com/2018/03/09/capital-one-virtual-credit-cards/",
+                        "https://o.aolcdn.com/images/dims?thumbnail=1200%2C630&quality=80&image_uri=https%3A%2F%2Fo.aolcdn.com%2Fimages%2Fdims%3Fcrop%3D3861%252C2574%252C0%252C0%26quality%3D85%26format%3Djpg%26resize%3D1600%252C1067%26image_uri%3Dhttp%253A%252F%252Fo.aolcdn.com%252Fhss%252Fstorage%252Fmidas%252Fca9d74d8d57677d4f3291ae4347b26da%252F206197048%252Fcapital-one-financial-corp-signage-is-displayed-at-a-bank-branch-in-picture-id120933061%26client%3Da1acac3e1b3290917d92%26signature%3Db51d9958f8487452f6a8c6d354650fcb339f0520&client=cbc79c14efcebee57402&signature=44e59feb505c1b9c4e5867d453d3ed345010acac",
+                        "2018-03-09T13:00:00Z",
+                        Source("engadget", "Engadget")
+                ),
+                Article(
+                        "Magic Leap gets \$461M more, Travis goes VC, and HQ Trivia scales up",
+                        "Hello and welcome back to Equity, TechCrunch’s venture capital-focused podcast where we unpack the numbers behind the headlines. This week we had a corking set of news to get through, so we rounded up the usual gang (Matthew Lynley, Katie Roof, and myself), a…",
+                        "http://techcrunch.com/2018/03/09/magic-leap-gets-461m-more-travis-goes-vc-and-hq-trivia-scales-up/",
+                        "https://tctechcrunch2011.files.wordpress.com/2017/03/tc-equity-podcast-ios.jpg",
+                        "2018-03-09T14:10:01Z",
+                        Source("techcrunch", "TechCrunch")
+                )
+        )
+    }
+}

--- a/app/src/test/java/me/jorgecastillo/hiroaki/services/SomeService.kt
+++ b/app/src/test/java/me/jorgecastillo/hiroaki/services/SomeService.kt
@@ -8,6 +8,7 @@ import retrofit2.Call
 import retrofit2.http.Body
 import retrofit2.http.GET
 import retrofit2.http.POST
+import retrofit2.http.Query
 
 interface SomeService {
 
@@ -34,4 +35,13 @@ interface SomeService {
      */
     @POST("/my-fake-service")
     fun publishHeadline(@Body articleDto: GsonArticleDto): Call<Void>
+
+    /**
+     * Added to test query param verification for lists.
+     */
+    @POST("/my-fake-service/edit-tag")
+    fun addNewsTags(
+        @Query("i") ids: List<String>,
+        @Query("a") tagIds: List<String>
+    ): Call<Void>
 }

--- a/hiroaki-core/src/main/java/me/jorgecastillo/hiroaki/Syntax.kt
+++ b/hiroaki-core/src/main/java/me/jorgecastillo/hiroaki/Syntax.kt
@@ -3,12 +3,11 @@ package me.jorgecastillo.hiroaki
 import me.jorgecastillo.hiroaki.Either.Left
 import me.jorgecastillo.hiroaki.Either.Right
 
-typealias NetworkDto = Class<*>
-typealias QueryParams = Map<String, String>
+typealias QueryParams = List<Pair<String, String>>
 typealias Headers = Map<String, String>
 
 fun params(vararg pairs: Pair<String, String>): QueryParams =
-        if (pairs.isNotEmpty()) pairs.toMap() else emptyMap()
+        if (pairs.isNotEmpty()) pairs.toList() else listOf()
 
 fun headers(vararg pairs: Pair<String, String>): Headers =
         if (pairs.isNotEmpty()) pairs.toMap() else emptyMap()

--- a/hiroaki-core/src/main/java/me/jorgecastillo/hiroaki/matchers/QueryParamsMatcher.kt
+++ b/hiroaki-core/src/main/java/me/jorgecastillo/hiroaki/matchers/QueryParamsMatcher.kt
@@ -9,24 +9,26 @@ import java.net.URLEncoder
 /**
  * Custom Hamcrest matcher to assert about query parameters on an OkHttp RecordedRequest.
  */
-fun hasQueryParams(params: Map<String, String>): Matcher<RecordedRequest> {
+fun hasQueryParams(expectedParams: List<Pair<String, String>>): Matcher<RecordedRequest> {
     return object : TypeSafeMatcher<RecordedRequest>() {
 
         override fun describeTo(description: Description) {
             description.appendText("The HTTP query should contain params: ")
-            params.forEach {
-                description.appendText("\n${it.key} = ${it.value}")
+            expectedParams.forEach {
+                description.appendText("\n${it.first} = ${it.second}")
             }
         }
 
         override fun describeMismatchSafely(request: RecordedRequest, mismatchDescription: Description) {
-            for ((key, value) in params) {
-                val parameter = request.requestUrl.queryParameter(key)
-                if (parameter == null) {
+            for ((key, value) in expectedParams) {
+                val requestedParamsForExpectedKey = request.requestUrl.queryParameterValues(key)
+                if (requestedParamsForExpectedKey == null ||
+                        requestedParamsForExpectedKey.isEmpty()) {
                     mismatchDescription.appendText("\nparameter $key is not present.")
                 } else {
-                    if (parameter != URLEncoder.encode(value, "UTF-8")) {
-                        mismatchDescription.appendText("\n$key = $parameter (Not matching!)")
+                    if (requestedParamsForExpectedKey
+                                    .find { it == URLEncoder.encode(value, "UTF-8") } == null) {
+                        mismatchDescription.appendText("\n$key = $value (Not matching!)")
                     }
                 }
             }
@@ -34,12 +36,14 @@ fun hasQueryParams(params: Map<String, String>): Matcher<RecordedRequest> {
 
         override fun matchesSafely(request: RecordedRequest): Boolean {
             var failed = false
-            for ((key, value) in params) {
-                val parameter = request.requestUrl.queryParameter(key)
-                if (parameter == null) {
+            for ((key, value) in expectedParams) {
+                val requestedParamsForExpectedKey = request.requestUrl.queryParameterValues(key)
+                if (requestedParamsForExpectedKey == null ||
+                        requestedParamsForExpectedKey.isEmpty()) {
                     failed = true
                 } else {
-                    if (parameter != URLEncoder.encode(value, "UTF-8")) {
+                    if (requestedParamsForExpectedKey
+                                    .find { it == URLEncoder.encode(value, "UTF-8") } == null) {
                         failed = true
                     }
                 }


### PR DESCRIPTION
### :pushpin: References
**Issues:**
* Fixes #50 

### :tophat: What is the goal?

Let's assume that I make the following request `https://example.com/add?i=1&i=2&i=3`. Is it possible to test that the response contains all of these parameters?

I've to tried to make a test like this: `server.verify("add").called(queryParams = params("i" to "1", "i" to "2", "i" to "3")))`, but that fails because each parameter overrides previous.

The goal is to not use a map anymore but a list of pairs so the key values do not get overriden.

### 💻 How is it being implemented?

* Start using `List<Pair<String, String>>` for `QueryParams` type alias instead of `Map<String, String>`. That makes keys non unique anymore since that's common in HTTP libraries like Retrofit (where you can send lists of strings for the same key).
* Updated `hasQueryParams` Hamcrest custom matcher to support matching against multiple recorded request query params.

### 📱 How to Test

* Let tests pass on CI.