### PR TITLE
fix encoding for query param matching

### DIFF
--- a/app/src/test/java/me/jorgecastillo/hiroaki/VerificationTest.kt
+++ b/app/src/test/java/me/jorgecastillo/hiroaki/VerificationTest.kt
@@ -1,8 +1,6 @@
 package me.jorgecastillo.hiroaki
 
 import me.jorgecastillo.hiroaki.internal.MockServerSuite
-import me.jorgecastillo.hiroaki.model.Article
-import me.jorgecastillo.hiroaki.model.Source
 import me.jorgecastillo.hiroaki.models.success
 import me.jorgecastillo.hiroaki.services.SomeService
 import org.junit.Before
@@ -76,32 +74,21 @@ class VerificationTest : MockServerSuite() {
                         "a" to "some-tag-3"))
     }
 
-    private fun expectedNews(): List<Article> {
-        return listOf(
-                Article(
-                        "How to Get Android P's Screenshot Editing Tool on Any Android Phone",
-                        "Last year, Apple brought advanced screenshot editing tools to the iPhone with iOS 11, and, this week, Google fired back with a similar Android feature called Markup. The only catch is that this new tool is limited to Android P, which launches later this year …",
-                        "https://lifehacker.com/how-to-get-android-ps-screenshot-editing-tool-on-any-an-1823646122",
-                        "https://i.kinja-img.com/gawker-media/image/upload/s--Y-5X_NcT--/c_fill,fl_progressive,g_center,h_450,q_80,w_800/nxmwbkwzoc1z1tmak7s4.jpg",
-                        "2018-03-09T20:30:00Z",
-                        Source(null, "Lifehacker.com")
-                ),
-                Article(
-                        "Capital One's virtual credit cards could help you avoid fraud",
-                        "Capital One is no stranger to trying new things -- especially when it comes to technology. Its Eno texting chatbot, for example, is a quick and conversational way for its customers to check their balances and perform simple tasks, like checking on recent tran…",
-                        "https://www.engadget.com/2018/03/09/capital-one-virtual-credit-cards/",
-                        "https://o.aolcdn.com/images/dims?thumbnail=1200%2C630&quality=80&image_uri=https%3A%2F%2Fo.aolcdn.com%2Fimages%2Fdims%3Fcrop%3D3861%252C2574%252C0%252C0%26quality%3D85%26format%3Djpg%26resize%3D1600%252C1067%26image_uri%3Dhttp%253A%252F%252Fo.aolcdn.com%252Fhss%252Fstorage%252Fmidas%252Fca9d74d8d57677d4f3291ae4347b26da%252F206197048%252Fcapital-one-financial-corp-signage-is-displayed-at-a-bank-branch-in-picture-id120933061%26client%3Da1acac3e1b3290917d92%26signature%3Db51d9958f8487452f6a8c6d354650fcb339f0520&client=cbc79c14efcebee57402&signature=44e59feb505c1b9c4e5867d453d3ed345010acac",
-                        "2018-03-09T13:00:00Z",
-                        Source("engadget", "Engadget")
-                ),
-                Article(
-                        "Magic Leap gets \$461M more, Travis goes VC, and HQ Trivia scales up",
-                        "Hello and welcome back to Equity, TechCrunch’s venture capital-focused podcast where we unpack the numbers behind the headlines. This week we had a corking set of news to get through, so we rounded up the usual gang (Matthew Lynley, Katie Roof, and myself), a…",
-                        "http://techcrunch.com/2018/03/09/magic-leap-gets-461m-more-travis-goes-vc-and-hq-trivia-scales-up/",
-                        "https://tctechcrunch2011.files.wordpress.com/2017/03/tc-equity-podcast-ios.jpg",
-                        "2018-03-09T14:10:01Z",
-                        Source("techcrunch", "TechCrunch")
-                )
-        )
+    @Test
+    fun supportsSpecialCharactersInQueryParamValues() {
+        server.whenever(Method.POST, "my-fake-service/edit-tag")
+                .thenRespond(success())
+
+        service.addNewsTags(listOf("1", "2", "3"), listOf("user/-/tag", "user/-/tag-2"))
+                .execute()
+
+        server.verify("my-fake-service/edit-tag").called(
+                times = once(),
+                queryParams = params(
+                        "i" to "1",
+                        "i" to "2",
+                        "i" to "3",
+                        "a" to "user/-/tag",
+                        "a" to "user/-/tag-2"))
     }
 }

--- a/hiroaki-core/src/main/java/me/jorgecastillo/hiroaki/matchers/QueryParamsMatcher.kt
+++ b/hiroaki-core/src/main/java/me/jorgecastillo/hiroaki/matchers/QueryParamsMatcher.kt
@@ -26,8 +26,7 @@ fun hasQueryParams(expectedParams: List<Pair<String, String>>): Matcher<Recorded
                         requestedParamsForExpectedKey.isEmpty()) {
                     mismatchDescription.appendText("\nparameter $key is not present.")
                 } else {
-                    if (requestedParamsForExpectedKey
-                                    .find { it == URLEncoder.encode(value, "UTF-8") } == null) {
+                    if (requestedParamsForExpectedKey.find { it == value } == null) {
                         mismatchDescription.appendText("\n$key = $value (Not matching!)")
                     }
                 }
@@ -42,8 +41,7 @@ fun hasQueryParams(expectedParams: List<Pair<String, String>>): Matcher<Recorded
                         requestedParamsForExpectedKey.isEmpty()) {
                     failed = true
                 } else {
-                    if (requestedParamsForExpectedKey
-                                    .find { it == URLEncoder.encode(value, "UTF-8") } == null) {
+                    if (requestedParamsForExpectedKey.find { it == value } == null) {
                         failed = true
                     }
                 }

--- a/hiroaki-core/src/main/java/me/jorgecastillo/hiroaki/matchers/QueryParamsMatcher.kt
+++ b/hiroaki-core/src/main/java/me/jorgecastillo/hiroaki/matchers/QueryParamsMatcher.kt
@@ -4,7 +4,6 @@ import okhttp3.mockwebserver.RecordedRequest
 import org.hamcrest.Description
 import org.hamcrest.Matcher
 import org.hamcrest.TypeSafeMatcher
-import java.net.URLEncoder
 
 /**
  * Custom Hamcrest matcher to assert about query parameters on an OkHttp RecordedRequest.


### PR DESCRIPTION
### :pushpin: References
**Issues:**
* Fixes #51 

### :tophat: What is the problem/goal?

```kt
// Definition
@POST("add-tag")
fun addTag(@Query("id") id: String): Call<Void>

// Usage
addTag("user/-/tag")

// Request: POST /add-tag?id=user%2F-%2Ftag HTTP/1.1

// Verification
server.verify("add-tag").called(queryParams = params("tag" to "user/-/tag"))
```

The following test fails at [this code fragment](https://github.com/JorgeCastilloPrz/hiroaki/blob/master/hiroaki-core/src/main/java/me/jorgecastillo/hiroaki/matchers/QueryParamsMatcher.kt#L42) where `user/-/tag` is compared to `user%2F-%2Ftag`.

This is due to the library encoding expected query param string values to utf8 before comparing, which is wrong.


### 💻 How is it being implemented?

* Remove utf8 encoding being done before matching expected vs requested query params.

### 📱 How to Test

* Let CI tests pass.