### PR TITLE
Upgrade to AndroidX

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-Hiroaki [![CircleCI](https://circleci.com/gh/JorgeCastilloPrz/hiroaki/tree/master.svg?style=svg&circle-token=3824cb7754fef5b81f1a67c6e86786df5db242c5)](https://circleci.com/gh/JorgeCastilloPrz/hiroaki/tree/master) [![MavenCentral/hiroaki-core](https://maven-badges.herokuapp.com/maven-central/me.jorgecastillo/hiroaki-core/badge.svg)](https://maven-badges.herokuapp.com/maven-central/me.jorgecastillo/hiroaki-core)
+Hiroaki [![CircleCI](https://circleci.com/gh/JorgeCastilloPrz/hiroaki/tree/master.svg?style=svg&circle-token=3824cb7754fef5b81f1a67c6e86786df5db242c5)](https://circleci.com/gh/JorgeCastilloPrz/hiroaki/tree/master)
 ======
 
 <img src="./art/sakura_logo.svg" width="256" height="256" />

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -60,8 +60,8 @@ dependencies {
     implementation "com.android.support:recyclerview-v7:$supportVersion"
     implementation "com.android.support:design:$supportVersion"
     implementation 'com.android.support.constraint:constraint-layout:1.1.3'
-    implementation 'com.android.support:design:27.1.0'
-    implementation 'com.squareup.picasso:picasso:2.5.2'
+    implementation "com.android.support:design:$supportVersion"
+    implementation 'com.squareup.picasso:picasso:2.71828'
 
     // Network
     implementation 'com.squareup.okhttp3:okhttp:3.10.0'

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -3,11 +3,11 @@ apply plugin: 'kotlin-android'
 apply plugin: 'kotlin-android-extensions'
 
 android {
-    compileSdkVersion 27
+    compileSdkVersion 28
     defaultConfig {
         applicationId "me.jorgecastillo.hiroaki"
         minSdkVersion 14
-        targetSdkVersion 27
+        targetSdkVersion 28
         versionCode 1
         versionName "0.0.1"
         testInstrumentationRunner "me.jorgecastillo.hiroaki.CustomTestRunner"

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -79,16 +79,16 @@ dependencies {
     testImplementation 'com.squareup.okhttp3:mockwebserver:3.11.0'
     androidTestImplementation 'com.squareup.okhttp3:mockwebserver:3.11.0'
     testImplementation 'junit:junit:4.12'
-    testImplementation 'com.android.support.test:runner:1.0.1'
-    testImplementation 'org.mockito:mockito-core:2.15.0'
-    testImplementation 'org.mockito:mockito-android:2.15.0'
+    testImplementation 'com.android.support.test:runner:1.0.2'
+    testImplementation 'org.mockito:mockito-core:2.19.0'
+    testImplementation 'org.mockito:mockito-android:2.19.0'
     testImplementation "com.nhaarman:mockito-kotlin:1.5.0"
 
     androidTestImplementation 'junit:junit:4.12'
-    androidTestImplementation 'org.mockito:mockito-core:2.15.0'
-    androidTestImplementation 'org.mockito:mockito-android:2.15.0'
+    androidTestImplementation 'org.mockito:mockito-core:2.19.0'
+    androidTestImplementation 'org.mockito:mockito-android:2.19.0'
     androidTestImplementation "com.nhaarman:mockito-kotlin:1.5.0"
-    androidTestImplementation 'com.android.support.test.espresso:espresso-core:3.0.1'
+    androidTestImplementation 'com.android.support.test.espresso:espresso-core:3.0.2'
     androidTestImplementation('com.android.support.test.espresso:espresso-contrib:3.0.1') {
         exclude module: 'support-annotations'
         exclude module: 'recyclerview-v7'

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -48,7 +48,7 @@ dependencies {
     androidTestImplementation project(":hiroaki-android")
 
     // Kotlin
-    implementation "org.jetbrains.kotlin:kotlin-stdlib-jre7:$kotlin_version"
+    implementation "org.jetbrains.kotlin:kotlin-stdlib-jdk7:$kotlin_version"
     implementation "org.jetbrains.kotlin:kotlin-reflect:$kotlin_version"
     implementation 'org.jetbrains.kotlinx:kotlinx-coroutines-core:0.22.5'
     implementation "org.jetbrains.kotlinx:kotlinx-coroutines-android:0.22.5"

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -39,7 +39,7 @@ kotlin {
 }
 
 dependencies {
-    def retrofitVersion = "2.3.0"
+    def retrofitVersion = "2.5.0"
 
     implementation 'androidx.multidex:multidex:2.0.1'
 

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -59,7 +59,7 @@ dependencies {
     implementation "com.android.support:cardview-v7:$supportVersion"
     implementation "com.android.support:recyclerview-v7:$supportVersion"
     implementation "com.android.support:design:$supportVersion"
-    implementation 'com.android.support.constraint:constraint-layout:1.0.2'
+    implementation 'com.android.support.constraint:constraint-layout:1.1.3'
     implementation 'com.android.support:design:27.1.0'
     implementation 'com.squareup.picasso:picasso:2.5.2'
 

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -87,7 +87,8 @@ dependencies {
     androidTestImplementation 'org.mockito:mockito-android:2.19.0'
     androidTestImplementation "com.nhaarman:mockito-kotlin:1.5.0"
     androidTestImplementation 'androidx.test.espresso:espresso-core:3.1.1'
-    androidTestImplementation('androidx.test.espresso:espresso-contrib:3.1.1')
+    androidTestImplementation'androidx.test.espresso:espresso-contrib:3.1.1'
+    androidTestImplementation 'androidx.test:rules:1.1.1'
 }
 
 apply from: '../ktlint/ktlint.gradle'

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -64,7 +64,7 @@ dependencies {
     implementation 'com.squareup.picasso:picasso:2.71828'
 
     // Network
-    implementation 'com.squareup.okhttp3:okhttp:3.10.0'
+    implementation 'com.squareup.okhttp3:okhttp:3.12.0'
     implementation 'com.squareup.okhttp3:logging-interceptor:3.10.0'
     implementation "com.squareup.retrofit2:retrofit:$retrofitVersion"
     implementation "com.squareup.retrofit2:converter-moshi:$retrofitVersion"
@@ -76,8 +76,8 @@ dependencies {
     implementation 'com.fasterxml.jackson.module:jackson-module-kotlin:2.9.4.1'
 
     // test
-    testImplementation 'com.squareup.okhttp3:mockwebserver:3.10.0'
-    androidTestImplementation 'com.squareup.okhttp3:mockwebserver:3.10.0'
+    testImplementation 'com.squareup.okhttp3:mockwebserver:3.11.0'
+    androidTestImplementation 'com.squareup.okhttp3:mockwebserver:3.11.0'
     testImplementation 'junit:junit:4.12'
     testImplementation 'com.android.support.test:runner:1.0.1'
     testImplementation 'org.mockito:mockito-core:2.15.0'

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -39,10 +39,9 @@ kotlin {
 }
 
 dependencies {
-    def supportVersion = "28.0.0"
     def retrofitVersion = "2.3.0"
 
-    implementation 'com.android.support:multidex:1.0.3'
+    implementation 'androidx.multidex:multidex:2.0.1'
 
     testImplementation project(":hiroaki-core")
     androidTestImplementation project(":hiroaki-android")
@@ -55,12 +54,11 @@ dependencies {
     ktlint "com.github.shyiko:ktlint:0.29.0"
 
     // UI
-    implementation "com.android.support:appcompat-v7:$supportVersion"
-    implementation "com.android.support:cardview-v7:$supportVersion"
-    implementation "com.android.support:recyclerview-v7:$supportVersion"
-    implementation "com.android.support:design:$supportVersion"
-    implementation 'com.android.support.constraint:constraint-layout:1.1.3'
-    implementation "com.android.support:design:$supportVersion"
+    implementation "androidx.appcompat:appcompat:1.0.2"
+    implementation "androidx.cardview:cardview:1.0.0"
+    implementation "androidx.recyclerview:recyclerview:1.0.0"
+    implementation "com.google.android.material:material:1.0.0"
+    implementation 'androidx.constraintlayout:constraintlayout:1.1.3'
     implementation 'com.squareup.picasso:picasso:2.71828'
 
     // Network
@@ -79,7 +77,7 @@ dependencies {
     testImplementation 'com.squareup.okhttp3:mockwebserver:3.11.0'
     androidTestImplementation 'com.squareup.okhttp3:mockwebserver:3.11.0'
     testImplementation 'junit:junit:4.12'
-    testImplementation 'com.android.support.test:runner:1.0.2'
+    testImplementation 'androidx.test:runner:1.1.1'
     testImplementation 'org.mockito:mockito-core:2.19.0'
     testImplementation 'org.mockito:mockito-android:2.19.0'
     testImplementation "com.nhaarman:mockito-kotlin:1.5.0"
@@ -88,13 +86,8 @@ dependencies {
     androidTestImplementation 'org.mockito:mockito-core:2.19.0'
     androidTestImplementation 'org.mockito:mockito-android:2.19.0'
     androidTestImplementation "com.nhaarman:mockito-kotlin:1.5.0"
-    androidTestImplementation 'com.android.support.test.espresso:espresso-core:3.0.2'
-    androidTestImplementation('com.android.support.test.espresso:espresso-contrib:3.0.1') {
-        exclude module: 'support-annotations'
-        exclude module: 'recyclerview-v7'
-        exclude module: 'support-v4'
-    }
+    androidTestImplementation 'androidx.test.espresso:espresso-core:3.1.1'
+    androidTestImplementation('androidx.test.espresso:espresso-contrib:3.1.1')
 }
 
 apply from: '../ktlint/ktlint.gradle'
-

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -43,8 +43,8 @@ dependencies {
 
     implementation 'androidx.multidex:multidex:2.0.1'
 
-    testImplementation project(":hiroaki-core")
-    androidTestImplementation project(":hiroaki-android")
+    testImplementation "me.jorgecastillo:hiroaki-core:0.1.0"
+    androidTestImplementation "me.jorgecastillo:hiroaki-android:0.1.0"
 
     // Kotlin
     implementation "org.jetbrains.kotlin:kotlin-stdlib-jdk7:$kotlin_version"

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -39,7 +39,7 @@ kotlin {
 }
 
 dependencies {
-    def supportVersion = "27.1.0"
+    def supportVersion = "28.0.0"
     def retrofitVersion = "2.3.0"
 
     implementation 'com.android.support:multidex:1.0.3'

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -52,7 +52,7 @@ dependencies {
     implementation "org.jetbrains.kotlin:kotlin-reflect:$kotlin_version"
     implementation 'org.jetbrains.kotlinx:kotlinx-coroutines-core:1.1.0'
     implementation "org.jetbrains.kotlinx:kotlinx-coroutines-android:1.1.0"
-    ktlint "com.github.shyiko:ktlint:0.19.0"
+    ktlint "com.github.shyiko:ktlint:0.29.0"
 
     // UI
     implementation "com.android.support:appcompat-v7:$supportVersion"

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -50,8 +50,8 @@ dependencies {
     // Kotlin
     implementation "org.jetbrains.kotlin:kotlin-stdlib-jdk7:$kotlin_version"
     implementation "org.jetbrains.kotlin:kotlin-reflect:$kotlin_version"
-    implementation 'org.jetbrains.kotlinx:kotlinx-coroutines-core:0.22.5'
-    implementation "org.jetbrains.kotlinx:kotlinx-coroutines-android:0.22.5"
+    implementation 'org.jetbrains.kotlinx:kotlinx-coroutines-core:1.1.0'
+    implementation "org.jetbrains.kotlinx:kotlinx-coroutines-android:1.1.0"
     ktlint "com.github.shyiko:ktlint:0.19.0"
 
     // UI

--- a/app/src/androidTest/java/me/jorgecastillo/hiroaki/AndroidVerificationTests.kt
+++ b/app/src/androidTest/java/me/jorgecastillo/hiroaki/AndroidVerificationTests.kt
@@ -1,10 +1,9 @@
 package me.jorgecastillo.hiroaki
 
 import android.content.Intent
-import android.support.test.filters.LargeTest
-import android.support.test.rule.ActivityTestRule
-import android.support.test.runner.AndroidJUnit4
-import kotlinx.coroutines.experimental.runBlocking
+import androidx.test.filters.LargeTest
+import androidx.test.rule.ActivityTestRule
+import androidx.test.runner.AndroidJUnit4
 import me.jorgecastillo.hiroaki.data.service.MoshiNewsApiService
 import me.jorgecastillo.hiroaki.internal.AndroidMockServerSuite
 import me.jorgecastillo.hiroaki.matchers.never
@@ -22,26 +21,26 @@ class AndroidVerificationTests : AndroidMockServerSuite() {
 
     @get:Rule
     val testRule: ActivityTestRule<MainActivity> = ActivityTestRule(
-            MainActivity::class.java, true, false)
+        MainActivity::class.java, true, false)
 
     @Before
     override fun setup() {
         super.setup()
         val mockService = server.retrofitService(
-                MoshiNewsApiService::class.java,
-                MoshiConverterFactory.create())
+            MoshiNewsApiService::class.java,
+            MoshiConverterFactory.create())
         getApp()
-                .service = mockService
+            .service = mockService
     }
 
     private fun startActivity(): MainActivity {
-        return runBlocking { testRule.launchActivity(Intent()) }
+        return testRule.launchActivity(Intent())
     }
 
     @Test
     fun verifiesEndpointCalled() {
         server.whenever(Method.GET, "v2/top-headlines")
-                .thenRespond(success(jsonBody = fileBody("GetNews.json")))
+            .thenRespond(success(jsonBody = fileBody("GetNews.json")))
 
         startActivity()
 
@@ -51,33 +50,33 @@ class AndroidVerificationTests : AndroidMockServerSuite() {
     @Test
     fun verifiesHeadersOnEndpointCalled() {
         server.whenever(Method.GET, "v2/top-headlines")
-                .thenRespond(success(jsonBody = fileBody("GetNews.json")))
+            .thenRespond(success(jsonBody = fileBody("GetNews.json")))
 
         startActivity()
 
         server.verify("v2/top-headlines").called(
-                times = once(),
-                headers = headers("Cache-Control" to "max-age=640000"))
+            times = once(),
+            headers = headers("Cache-Control" to "max-age=640000"))
     }
 
     @Test
     fun verifiesQueryParamsOnEndpointCalled() {
         server.whenever(Method.GET, "v2/top-headlines")
-                .thenRespond(success(jsonBody = fileBody("GetNews.json")))
+            .thenRespond(success(jsonBody = fileBody("GetNews.json")))
 
         startActivity()
 
         server.verify("v2/top-headlines").called(
-                times = once(),
-                queryParams = params(
-                        "sources" to "crypto-coins-news",
-                        "apiKey" to "a7c816f57c004c49a21bd458e11e2807"))
+            times = once(),
+            queryParams = params(
+                "sources" to "crypto-coins-news",
+                "apiKey" to "a7c816f57c004c49a21bd458e11e2807"))
     }
 
     @Test
     fun verifiesEndpointNotCalled() {
         server.whenever(Method.GET, "v2/top-headlines")
-                .thenRespond(success(jsonBody = fileBody("GetNews.json")))
+            .thenRespond(success(jsonBody = fileBody("GetNews.json")))
 
         startActivity()
 

--- a/app/src/androidTest/java/me/jorgecastillo/hiroaki/ApplicationSyntax.kt
+++ b/app/src/androidTest/java/me/jorgecastillo/hiroaki/ApplicationSyntax.kt
@@ -1,8 +1,8 @@
 package me.jorgecastillo.hiroaki
 
-import android.support.test.InstrumentationRegistry
+import androidx.test.platform.app.InstrumentationRegistry
 
 fun getApp() =
     (InstrumentationRegistry.getInstrumentation()
-            .targetContext
-            .applicationContext as TestSampleApp)
+        .targetContext
+        .applicationContext as TestSampleApp)

--- a/app/src/androidTest/java/me/jorgecastillo/hiroaki/CustomTestRunner.kt
+++ b/app/src/androidTest/java/me/jorgecastillo/hiroaki/CustomTestRunner.kt
@@ -2,14 +2,14 @@ package me.jorgecastillo.hiroaki
 
 import android.app.Application
 import android.content.Context
-import android.support.test.runner.AndroidJUnitRunner
+import androidx.test.runner.AndroidJUnitRunner
 
 class CustomTestRunner : AndroidJUnitRunner() {
 
-    @Throws(InstantiationException::class, IllegalAccessException::class, ClassNotFoundException::class)
-    override fun newApplication(
-        cl: ClassLoader,
-        className: String,
-        context: Context
-    ): Application = super.newApplication(cl, TestSampleApp::class.java.name, context)
+  @Throws(InstantiationException::class, IllegalAccessException::class, ClassNotFoundException::class)
+  override fun newApplication(
+      cl: ClassLoader,
+      className: String,
+      context: Context
+  ): Application = super.newApplication(cl, TestSampleApp::class.java.name, context)
 }

--- a/app/src/androidTest/java/me/jorgecastillo/hiroaki/CustomTestRunner.kt
+++ b/app/src/androidTest/java/me/jorgecastillo/hiroaki/CustomTestRunner.kt
@@ -6,10 +6,10 @@ import androidx.test.runner.AndroidJUnitRunner
 
 class CustomTestRunner : AndroidJUnitRunner() {
 
-  @Throws(InstantiationException::class, IllegalAccessException::class, ClassNotFoundException::class)
-  override fun newApplication(
-      cl: ClassLoader,
-      className: String,
-      context: Context
-  ): Application = super.newApplication(cl, TestSampleApp::class.java.name, context)
+    @Throws(InstantiationException::class, IllegalAccessException::class, ClassNotFoundException::class)
+    override fun newApplication(
+        cl: ClassLoader,
+        className: String,
+        context: Context
+    ): Application = super.newApplication(cl, TestSampleApp::class.java.name, context)
 }

--- a/app/src/androidTest/java/me/jorgecastillo/hiroaki/ExampleInstrumentedTest.kt
+++ b/app/src/androidTest/java/me/jorgecastillo/hiroaki/ExampleInstrumentedTest.kt
@@ -1,14 +1,14 @@
 package me.jorgecastillo.hiroaki
 
 import android.content.Intent
-import android.support.test.espresso.Espresso.onView
-import android.support.test.espresso.assertion.ViewAssertions.matches
-import android.support.test.espresso.matcher.ViewMatchers.isDisplayed
-import android.support.test.espresso.matcher.ViewMatchers.withText
-import android.support.test.filters.LargeTest
-import android.support.test.rule.ActivityTestRule
-import android.support.test.runner.AndroidJUnit4
-import kotlinx.coroutines.experimental.runBlocking
+import androidx.test.espresso.Espresso.onView
+import androidx.test.espresso.assertion.ViewAssertions.matches
+import androidx.test.espresso.matcher.ViewMatchers.isDisplayed
+import androidx.test.espresso.matcher.ViewMatchers.withText
+import androidx.test.filters.LargeTest
+import androidx.test.rule.ActivityTestRule
+import androidx.test.runner.AndroidJUnit4
+import kotlinx.coroutines.runBlocking
 import me.jorgecastillo.hiroaki.Method.GET
 import me.jorgecastillo.hiroaki.data.service.MoshiNewsApiService
 import me.jorgecastillo.hiroaki.internal.AndroidMockServerSuite
@@ -28,16 +28,16 @@ class ExampleInstrumentedTest : AndroidMockServerSuite() {
 
     @get:Rule
     val testRule: ActivityTestRule<MainActivity> = ActivityTestRule(
-            MainActivity::class.java, true, false)
+        MainActivity::class.java, true, false)
 
     @Before
     override fun setup() {
         super.setup()
         val mockService = server.retrofitService(
-                MoshiNewsApiService::class.java,
-                MoshiConverterFactory.create())
+            MoshiNewsApiService::class.java,
+            MoshiConverterFactory.create())
         getApp()
-                .service = mockService
+            .service = mockService
     }
 
     private fun startActivity(): MainActivity {
@@ -47,7 +47,7 @@ class ExampleInstrumentedTest : AndroidMockServerSuite() {
     @Test
     fun showsEmptyCaseIfThereAreNoSuperHeroes() {
         server.whenever(GET, "v2/top-headlines")
-                .thenRespond(success(jsonBody = fileBody("GetNews.json")))
+            .thenRespond(success(jsonBody = fileBody("GetNews.json")))
 
         startActivity()
 
@@ -57,30 +57,30 @@ class ExampleInstrumentedTest : AndroidMockServerSuite() {
 
     private fun expectedNews(): List<Article> {
         return listOf(
-                Article(
-                        "How to Get Android P's Screenshot Editing Tool on Any Android Phone",
-                        "Last year, Apple brought advanced screenshot editing tools to the iPhone with iOS 11, and, this week, Google fired back with a similar Android feature called Markup. The only catch is that this new tool is limited to Android P, which launches later this year …",
-                        "https://lifehacker.com/how-to-get-android-ps-screenshot-editing-tool-on-any-an-1823646122",
-                        "https://i.kinja-img.com/gawker-media/image/upload/s--Y-5X_NcT--/c_fill,fl_progressive,g_center,h_450,q_80,w_800/nxmwbkwzoc1z1tmak7s4.jpg",
-                        "2018-03-09T20:30:00Z",
-                        Source(null, "Lifehacker.com")
-                ),
-                Article(
-                        "Capital One's virtual credit cards could help you avoid fraud",
-                        "Capital One is no stranger to trying new things -- especially when it comes to technology. Its Eno texting chatbot, for example, is a quick and conversational way for its customers to check their balances and perform simple tasks, like checking on recent tran…",
-                        "https://www.engadget.com/2018/03/09/capital-one-virtual-credit-cards/",
-                        "https://o.aolcdn.com/images/dims?thumbnail=1200%2C630&quality=80&image_uri=https%3A%2F%2Fo.aolcdn.com%2Fimages%2Fdims%3Fcrop%3D3861%252C2574%252C0%252C0%26quality%3D85%26format%3Djpg%26resize%3D1600%252C1067%26image_uri%3Dhttp%253A%252F%252Fo.aolcdn.com%252Fhss%252Fstorage%252Fmidas%252Fca9d74d8d57677d4f3291ae4347b26da%252F206197048%252Fcapital-one-financial-corp-signage-is-displayed-at-a-bank-branch-in-picture-id120933061%26client%3Da1acac3e1b3290917d92%26signature%3Db51d9958f8487452f6a8c6d354650fcb339f0520&client=cbc79c14efcebee57402&signature=44e59feb505c1b9c4e5867d453d3ed345010acac",
-                        "2018-03-09T13:00:00Z",
-                        Source("engadget", "Engadget")
-                ),
-                Article(
-                        "Magic Leap gets \$461M more, Travis goes VC, and HQ Trivia scales up",
-                        "Hello and welcome back to Equity, TechCrunch’s venture capital-focused podcast where we unpack the numbers behind the headlines. This week we had a corking set of news to get through, so we rounded up the usual gang (Matthew Lynley, Katie Roof, and myself), a…",
-                        "http://techcrunch.com/2018/03/09/magic-leap-gets-461m-more-travis-goes-vc-and-hq-trivia-scales-up/",
-                        "https://tctechcrunch2011.files.wordpress.com/2017/03/tc-equity-podcast-ios.jpg",
-                        "2018-03-09T14:10:01Z",
-                        Source("techcrunch", "TechCrunch")
-                )
+            Article(
+                "How to Get Android P's Screenshot Editing Tool on Any Android Phone",
+                "Last year, Apple brought advanced screenshot editing tools to the iPhone with iOS 11, and, this week, Google fired back with a similar Android feature called Markup. The only catch is that this new tool is limited to Android P, which launches later this year …",
+                "https://lifehacker.com/how-to-get-android-ps-screenshot-editing-tool-on-any-an-1823646122",
+                "https://i.kinja-img.com/gawker-media/image/upload/s--Y-5X_NcT--/c_fill,fl_progressive,g_center,h_450,q_80,w_800/nxmwbkwzoc1z1tmak7s4.jpg",
+                "2018-03-09T20:30:00Z",
+                Source(null, "Lifehacker.com")
+            ),
+            Article(
+                "Capital One's virtual credit cards could help you avoid fraud",
+                "Capital One is no stranger to trying new things -- especially when it comes to technology. Its Eno texting chatbot, for example, is a quick and conversational way for its customers to check their balances and perform simple tasks, like checking on recent tran…",
+                "https://www.engadget.com/2018/03/09/capital-one-virtual-credit-cards/",
+                "https://o.aolcdn.com/images/dims?thumbnail=1200%2C630&quality=80&image_uri=https%3A%2F%2Fo.aolcdn.com%2Fimages%2Fdims%3Fcrop%3D3861%252C2574%252C0%252C0%26quality%3D85%26format%3Djpg%26resize%3D1600%252C1067%26image_uri%3Dhttp%253A%252F%252Fo.aolcdn.com%252Fhss%252Fstorage%252Fmidas%252Fca9d74d8d57677d4f3291ae4347b26da%252F206197048%252Fcapital-one-financial-corp-signage-is-displayed-at-a-bank-branch-in-picture-id120933061%26client%3Da1acac3e1b3290917d92%26signature%3Db51d9958f8487452f6a8c6d354650fcb339f0520&client=cbc79c14efcebee57402&signature=44e59feb505c1b9c4e5867d453d3ed345010acac",
+                "2018-03-09T13:00:00Z",
+                Source("engadget", "Engadget")
+            ),
+            Article(
+                "Magic Leap gets \$461M more, Travis goes VC, and HQ Trivia scales up",
+                "Hello and welcome back to Equity, TechCrunch’s venture capital-focused podcast where we unpack the numbers behind the headlines. This week we had a corking set of news to get through, so we rounded up the usual gang (Matthew Lynley, Katie Roof, and myself), a…",
+                "http://techcrunch.com/2018/03/09/magic-leap-gets-461m-more-travis-goes-vc-and-hq-trivia-scales-up/",
+                "https://tctechcrunch2011.files.wordpress.com/2017/03/tc-equity-podcast-ios.jpg",
+                "2018-03-09T14:10:01Z",
+                Source("techcrunch", "TechCrunch")
+            )
         )
     }
 }

--- a/app/src/androidTest/java/me/jorgecastillo/hiroaki/RuleAndroidVerificationTests.kt
+++ b/app/src/androidTest/java/me/jorgecastillo/hiroaki/RuleAndroidVerificationTests.kt
@@ -1,10 +1,10 @@
 package me.jorgecastillo.hiroaki
 
 import android.content.Intent
-import android.support.test.filters.LargeTest
-import android.support.test.rule.ActivityTestRule
-import android.support.test.runner.AndroidJUnit4
-import kotlinx.coroutines.experimental.runBlocking
+import androidx.test.filters.LargeTest
+import androidx.test.rule.ActivityTestRule
+import androidx.test.runner.AndroidJUnit4
+import kotlinx.coroutines.runBlocking
 import me.jorgecastillo.hiroaki.data.service.MoshiNewsApiService
 import me.jorgecastillo.hiroaki.internal.AndroidMockServerRule
 import me.jorgecastillo.hiroaki.matchers.never
@@ -24,15 +24,15 @@ class RuleAndroidVerificationTests {
     val testRule: AndroidMockServerRule = AndroidMockServerRule()
     @get:Rule
     val activityRule: ActivityTestRule<MainActivity> = ActivityTestRule(
-            MainActivity::class.java, true, false)
+        MainActivity::class.java, true, false)
 
     @Before
     fun setup() {
         val mockService = testRule.server.retrofitService(
-                MoshiNewsApiService::class.java,
-                MoshiConverterFactory.create())
+            MoshiNewsApiService::class.java,
+            MoshiConverterFactory.create())
         getApp()
-                .service = mockService
+            .service = mockService
     }
 
     private fun startActivity(): MainActivity {
@@ -42,7 +42,7 @@ class RuleAndroidVerificationTests {
     @Test
     fun verifiesEndpointCalled() {
         testRule.server.whenever(Method.GET, "v2/top-headlines")
-                .thenRespond(success(jsonBody = fileBody("GetNews.json")))
+            .thenRespond(success(jsonBody = fileBody("GetNews.json")))
 
         startActivity()
 
@@ -52,33 +52,33 @@ class RuleAndroidVerificationTests {
     @Test
     fun verifiesHeadersOnEndpointCalled() {
         testRule.server.whenever(Method.GET, "v2/top-headlines")
-                .thenRespond(success(jsonBody = fileBody("GetNews.json")))
+            .thenRespond(success(jsonBody = fileBody("GetNews.json")))
 
         startActivity()
 
         testRule.server.verify("v2/top-headlines").called(
-                times = once(),
-                headers = headers("Cache-Control" to "max-age=640000"))
+            times = once(),
+            headers = headers("Cache-Control" to "max-age=640000"))
     }
 
     @Test
     fun verifiesQueryParamsOnEndpointCalled() {
         testRule.server.whenever(Method.GET, "v2/top-headlines")
-                .thenRespond(success(jsonBody = fileBody("GetNews.json")))
+            .thenRespond(success(jsonBody = fileBody("GetNews.json")))
 
         startActivity()
 
         testRule.server.verify("v2/top-headlines").called(
-                times = once(),
-                queryParams = params(
-                        "sources" to "crypto-coins-news",
-                        "apiKey" to "a7c816f57c004c49a21bd458e11e2807"))
+            times = once(),
+            queryParams = params(
+                "sources" to "crypto-coins-news",
+                "apiKey" to "a7c816f57c004c49a21bd458e11e2807"))
     }
 
     @Test
     fun verifiesEndpointNotCalled() {
         testRule.server.whenever(Method.GET, "v2/top-headlines")
-                .thenRespond(success(jsonBody = fileBody("GetNews.json")))
+            .thenRespond(success(jsonBody = fileBody("GetNews.json")))
 
         startActivity()
 

--- a/app/src/androidTest/java/me/jorgecastillo/hiroaki/RuleExampleInstrumentedTest.kt
+++ b/app/src/androidTest/java/me/jorgecastillo/hiroaki/RuleExampleInstrumentedTest.kt
@@ -1,14 +1,14 @@
 package me.jorgecastillo.hiroaki
 
 import android.content.Intent
-import android.support.test.espresso.Espresso.onView
-import android.support.test.espresso.assertion.ViewAssertions.matches
-import android.support.test.espresso.matcher.ViewMatchers.isDisplayed
-import android.support.test.espresso.matcher.ViewMatchers.withText
-import android.support.test.filters.LargeTest
-import android.support.test.rule.ActivityTestRule
-import android.support.test.runner.AndroidJUnit4
-import kotlinx.coroutines.experimental.runBlocking
+import androidx.test.espresso.Espresso.onView
+import androidx.test.espresso.assertion.ViewAssertions.matches
+import androidx.test.espresso.matcher.ViewMatchers.isDisplayed
+import androidx.test.espresso.matcher.ViewMatchers.withText
+import androidx.test.filters.LargeTest
+import androidx.test.rule.ActivityTestRule
+import androidx.test.runner.AndroidJUnit4
+import kotlinx.coroutines.runBlocking
 import me.jorgecastillo.hiroaki.Method.GET
 import me.jorgecastillo.hiroaki.data.service.MoshiNewsApiService
 import me.jorgecastillo.hiroaki.internal.AndroidMockServerRule
@@ -30,15 +30,15 @@ class RuleExampleInstrumentedTest {
     val testRule: AndroidMockServerRule = AndroidMockServerRule()
     @get:Rule
     val activityRule: ActivityTestRule<MainActivity> = ActivityTestRule(
-            MainActivity::class.java, true, false)
+        MainActivity::class.java, true, false)
 
     @Before
     fun setup() {
         val mockService = testRule.server.retrofitService(
-                MoshiNewsApiService::class.java,
-                MoshiConverterFactory.create())
+            MoshiNewsApiService::class.java,
+            MoshiConverterFactory.create())
         getApp()
-                .service = mockService
+            .service = mockService
     }
 
     private fun startActivity(): MainActivity {
@@ -48,7 +48,7 @@ class RuleExampleInstrumentedTest {
     @Test
     fun showsEmptyCaseIfThereAreNoSuperHeroes() {
         testRule.server.whenever(GET, "v2/top-headlines")
-                .thenRespond(success(jsonBody = fileBody("GetNews.json")))
+            .thenRespond(success(jsonBody = fileBody("GetNews.json")))
 
         startActivity()
 
@@ -58,30 +58,30 @@ class RuleExampleInstrumentedTest {
 
     private fun expectedNews(): List<Article> {
         return listOf(
-                Article(
-                        "How to Get Android P's Screenshot Editing Tool on Any Android Phone",
-                        "Last year, Apple brought advanced screenshot editing tools to the iPhone with iOS 11, and, this week, Google fired back with a similar Android feature called Markup. The only catch is that this new tool is limited to Android P, which launches later this year …",
-                        "https://lifehacker.com/how-to-get-android-ps-screenshot-editing-tool-on-any-an-1823646122",
-                        "https://i.kinja-img.com/gawker-media/image/upload/s--Y-5X_NcT--/c_fill,fl_progressive,g_center,h_450,q_80,w_800/nxmwbkwzoc1z1tmak7s4.jpg",
-                        "2018-03-09T20:30:00Z",
-                        Source(null, "Lifehacker.com")
-                ),
-                Article(
-                        "Capital One's virtual credit cards could help you avoid fraud",
-                        "Capital One is no stranger to trying new things -- especially when it comes to technology. Its Eno texting chatbot, for example, is a quick and conversational way for its customers to check their balances and perform simple tasks, like checking on recent tran…",
-                        "https://www.engadget.com/2018/03/09/capital-one-virtual-credit-cards/",
-                        "https://o.aolcdn.com/images/dims?thumbnail=1200%2C630&quality=80&image_uri=https%3A%2F%2Fo.aolcdn.com%2Fimages%2Fdims%3Fcrop%3D3861%252C2574%252C0%252C0%26quality%3D85%26format%3Djpg%26resize%3D1600%252C1067%26image_uri%3Dhttp%253A%252F%252Fo.aolcdn.com%252Fhss%252Fstorage%252Fmidas%252Fca9d74d8d57677d4f3291ae4347b26da%252F206197048%252Fcapital-one-financial-corp-signage-is-displayed-at-a-bank-branch-in-picture-id120933061%26client%3Da1acac3e1b3290917d92%26signature%3Db51d9958f8487452f6a8c6d354650fcb339f0520&client=cbc79c14efcebee57402&signature=44e59feb505c1b9c4e5867d453d3ed345010acac",
-                        "2018-03-09T13:00:00Z",
-                        Source("engadget", "Engadget")
-                ),
-                Article(
-                        "Magic Leap gets \$461M more, Travis goes VC, and HQ Trivia scales up",
-                        "Hello and welcome back to Equity, TechCrunch’s venture capital-focused podcast where we unpack the numbers behind the headlines. This week we had a corking set of news to get through, so we rounded up the usual gang (Matthew Lynley, Katie Roof, and myself), a…",
-                        "http://techcrunch.com/2018/03/09/magic-leap-gets-461m-more-travis-goes-vc-and-hq-trivia-scales-up/",
-                        "https://tctechcrunch2011.files.wordpress.com/2017/03/tc-equity-podcast-ios.jpg",
-                        "2018-03-09T14:10:01Z",
-                        Source("techcrunch", "TechCrunch")
-                )
+            Article(
+                "How to Get Android P's Screenshot Editing Tool on Any Android Phone",
+                "Last year, Apple brought advanced screenshot editing tools to the iPhone with iOS 11, and, this week, Google fired back with a similar Android feature called Markup. The only catch is that this new tool is limited to Android P, which launches later this year …",
+                "https://lifehacker.com/how-to-get-android-ps-screenshot-editing-tool-on-any-an-1823646122",
+                "https://i.kinja-img.com/gawker-media/image/upload/s--Y-5X_NcT--/c_fill,fl_progressive,g_center,h_450,q_80,w_800/nxmwbkwzoc1z1tmak7s4.jpg",
+                "2018-03-09T20:30:00Z",
+                Source(null, "Lifehacker.com")
+            ),
+            Article(
+                "Capital One's virtual credit cards could help you avoid fraud",
+                "Capital One is no stranger to trying new things -- especially when it comes to technology. Its Eno texting chatbot, for example, is a quick and conversational way for its customers to check their balances and perform simple tasks, like checking on recent tran…",
+                "https://www.engadget.com/2018/03/09/capital-one-virtual-credit-cards/",
+                "https://o.aolcdn.com/images/dims?thumbnail=1200%2C630&quality=80&image_uri=https%3A%2F%2Fo.aolcdn.com%2Fimages%2Fdims%3Fcrop%3D3861%252C2574%252C0%252C0%26quality%3D85%26format%3Djpg%26resize%3D1600%252C1067%26image_uri%3Dhttp%253A%252F%252Fo.aolcdn.com%252Fhss%252Fstorage%252Fmidas%252Fca9d74d8d57677d4f3291ae4347b26da%252F206197048%252Fcapital-one-financial-corp-signage-is-displayed-at-a-bank-branch-in-picture-id120933061%26client%3Da1acac3e1b3290917d92%26signature%3Db51d9958f8487452f6a8c6d354650fcb339f0520&client=cbc79c14efcebee57402&signature=44e59feb505c1b9c4e5867d453d3ed345010acac",
+                "2018-03-09T13:00:00Z",
+                Source("engadget", "Engadget")
+            ),
+            Article(
+                "Magic Leap gets \$461M more, Travis goes VC, and HQ Trivia scales up",
+                "Hello and welcome back to Equity, TechCrunch’s venture capital-focused podcast where we unpack the numbers behind the headlines. This week we had a corking set of news to get through, so we rounded up the usual gang (Matthew Lynley, Katie Roof, and myself), a…",
+                "http://techcrunch.com/2018/03/09/magic-leap-gets-461m-more-travis-goes-vc-and-hq-trivia-scales-up/",
+                "https://tctechcrunch2011.files.wordpress.com/2017/03/tc-equity-podcast-ios.jpg",
+                "2018-03-09T14:10:01Z",
+                Source("techcrunch", "TechCrunch")
+            )
         )
     }
 }

--- a/app/src/main/java/me/jorgecastillo/hiroaki/MainActivity.kt
+++ b/app/src/main/java/me/jorgecastillo/hiroaki/MainActivity.kt
@@ -15,45 +15,45 @@ import me.jorgecastillo.hiroaki.data.datasource.MoshiNewsNetworkDataSource
 
 class MainActivity : AppCompatActivity() {
 
-  private lateinit var adapter: NewsAdapter
+    private lateinit var adapter: NewsAdapter
 
-  override fun onCreate(savedInstanceState: Bundle?) {
-    super.onCreate(savedInstanceState)
-    setContentView(R.layout.activity_main)
-    setSupportActionBar(toolbar)
-    setupList()
-  }
-
-  private fun setupList() {
-    newsList.setHasFixedSize(true)
-    newsList.layoutManager = LinearLayoutManager(this)
-    adapter = NewsAdapter()
-    newsList.adapter = adapter
-  }
-
-  override fun onResume() {
-    super.onResume()
-    GlobalScope.launch(Dispatchers.IO) {
-      withContext(Dispatchers.Main) {
-        loading.visibility = View.VISIBLE
-      }
-      val articles = MoshiNewsNetworkDataSource(getApp().newsService())
-          .getNews()
-      withContext(Dispatchers.Main) {
-        adapter.articles = articles
-        adapter.notifyDataSetChanged()
-        loading.visibility = View.GONE
-      }
+    override fun onCreate(savedInstanceState: Bundle?) {
+        super.onCreate(savedInstanceState)
+        setContentView(R.layout.activity_main)
+        setSupportActionBar(toolbar)
+        setupList()
     }
-  }
 
-  override fun onOptionsItemSelected(item: MenuItem): Boolean = when (item.itemId) {
-    R.id.action_settings -> true
-    else -> super.onOptionsItemSelected(item)
-  }
+    private fun setupList() {
+        newsList.setHasFixedSize(true)
+        newsList.layoutManager = LinearLayoutManager(this)
+        adapter = NewsAdapter()
+        newsList.adapter = adapter
+    }
 
-  override fun onCreateOptionsMenu(menu: Menu): Boolean {
-    menuInflater.inflate(R.menu.menu_main, menu)
-    return true
-  }
+    override fun onResume() {
+        super.onResume()
+        GlobalScope.launch(Dispatchers.IO) {
+            withContext(Dispatchers.Main) {
+                loading.visibility = View.VISIBLE
+            }
+            val articles = MoshiNewsNetworkDataSource(getApp().newsService())
+                    .getNews()
+            withContext(Dispatchers.Main) {
+                adapter.articles = articles
+                adapter.notifyDataSetChanged()
+                loading.visibility = View.GONE
+            }
+        }
+    }
+
+    override fun onOptionsItemSelected(item: MenuItem): Boolean = when (item.itemId) {
+        R.id.action_settings -> true
+        else -> super.onOptionsItemSelected(item)
+    }
+
+    override fun onCreateOptionsMenu(menu: Menu): Boolean {
+        menuInflater.inflate(R.menu.menu_main, menu)
+        return true
+    }
 }

--- a/app/src/main/java/me/jorgecastillo/hiroaki/MainActivity.kt
+++ b/app/src/main/java/me/jorgecastillo/hiroaki/MainActivity.kt
@@ -1,55 +1,59 @@
 package me.jorgecastillo.hiroaki
 
 import android.os.Bundle
-import android.support.v7.app.AppCompatActivity
-import android.support.v7.widget.LinearLayoutManager
 import android.view.Menu
 import android.view.MenuItem
 import android.view.View
-import kotlinx.android.synthetic.main.activity_main.loading
-import kotlinx.android.synthetic.main.activity_main.newsList
-import kotlinx.android.synthetic.main.activity_main.toolbar
-import kotlinx.coroutines.experimental.android.UI
-import kotlinx.coroutines.experimental.launch
+import androidx.appcompat.app.AppCompatActivity
+import androidx.recyclerview.widget.LinearLayoutManager
+import kotlinx.android.synthetic.main.activity_main.*
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.GlobalScope
+import kotlinx.coroutines.launch
+import kotlinx.coroutines.withContext
 import me.jorgecastillo.hiroaki.data.datasource.MoshiNewsNetworkDataSource
 
 class MainActivity : AppCompatActivity() {
 
-    private lateinit var adapter: NewsAdapter
+  private lateinit var adapter: NewsAdapter
 
-    override fun onCreate(savedInstanceState: Bundle?) {
-        super.onCreate(savedInstanceState)
-        setContentView(R.layout.activity_main)
-        setSupportActionBar(toolbar)
-        setupList()
-    }
+  override fun onCreate(savedInstanceState: Bundle?) {
+    super.onCreate(savedInstanceState)
+    setContentView(R.layout.activity_main)
+    setSupportActionBar(toolbar)
+    setupList()
+  }
 
-    private fun setupList() {
-        newsList.setHasFixedSize(true)
-        newsList.layoutManager = LinearLayoutManager(this)
-        adapter = NewsAdapter()
-        newsList.adapter = adapter
-    }
+  private fun setupList() {
+    newsList.setHasFixedSize(true)
+    newsList.layoutManager = LinearLayoutManager(this)
+    adapter = NewsAdapter()
+    newsList.adapter = adapter
+  }
 
-    override fun onResume() {
-        super.onResume()
-        launch(UI) {
-            loading.visibility = View.VISIBLE
-            val articles = MoshiNewsNetworkDataSource(getApp().newsService())
-                    .getNews()
-            adapter.articles = articles
-            adapter.notifyDataSetChanged()
-            loading.visibility = View.GONE
-        }
+  override fun onResume() {
+    super.onResume()
+    GlobalScope.launch(Dispatchers.IO) {
+      withContext(Dispatchers.Main) {
+        loading.visibility = View.VISIBLE
+      }
+      val articles = MoshiNewsNetworkDataSource(getApp().newsService())
+          .getNews()
+      withContext(Dispatchers.Main) {
+        adapter.articles = articles
+        adapter.notifyDataSetChanged()
+        loading.visibility = View.GONE
+      }
     }
+  }
 
-    override fun onOptionsItemSelected(item: MenuItem): Boolean = when (item.itemId) {
-        R.id.action_settings -> true
-        else -> super.onOptionsItemSelected(item)
-    }
+  override fun onOptionsItemSelected(item: MenuItem): Boolean = when (item.itemId) {
+    R.id.action_settings -> true
+    else -> super.onOptionsItemSelected(item)
+  }
 
-    override fun onCreateOptionsMenu(menu: Menu): Boolean {
-        menuInflater.inflate(R.menu.menu_main, menu)
-        return true
-    }
+  override fun onCreateOptionsMenu(menu: Menu): Boolean {
+    menuInflater.inflate(R.menu.menu_main, menu)
+    return true
+  }
 }

--- a/app/src/main/java/me/jorgecastillo/hiroaki/MainActivity.kt
+++ b/app/src/main/java/me/jorgecastillo/hiroaki/MainActivity.kt
@@ -33,12 +33,13 @@ class MainActivity : AppCompatActivity() {
 
     override fun onResume() {
         super.onResume()
-        GlobalScope.launch(Dispatchers.IO) {
-            withContext(Dispatchers.Main) {
-                loading.visibility = View.VISIBLE
-            }
-            val articles = MoshiNewsNetworkDataSource(getApp().newsService())
+        GlobalScope.launch(Dispatchers.Main) {
+            loading.visibility = View.VISIBLE
+
+            val articles = withContext(Dispatchers.IO) {
+                MoshiNewsNetworkDataSource(getApp().newsService())
                     .getNews()
+            }
             withContext(Dispatchers.Main) {
                 adapter.articles = articles
                 adapter.notifyDataSetChanged()

--- a/app/src/main/java/me/jorgecastillo/hiroaki/NewsAdapter.kt
+++ b/app/src/main/java/me/jorgecastillo/hiroaki/NewsAdapter.kt
@@ -12,29 +12,29 @@ import java.util.Locale
 import kotlin.collections.ArrayList
 
 class NewsAdapter(var articles: List<Article> = ArrayList()) :
-    RecyclerView.Adapter<ViewHolder>() {
+        RecyclerView.Adapter<ViewHolder>() {
 
-  override fun onCreateViewHolder(parent: ViewGroup, pos: Int): ViewHolder {
-    val view = LayoutInflater.from(parent.context)
-        .inflate(R.layout.item_article, parent, false)
-    return ViewHolder(view)
-  }
-
-  override fun onBindViewHolder(holder: ViewHolder, pos: Int) {
-    holder.bind(articles[pos])
-  }
-
-  override fun getItemCount() = articles.size
-
-  class ViewHolder(view: View) : RecyclerView.ViewHolder(view) {
-
-    fun bind(article: Article) {
-      itemView.picture.load(article.urlToImage)
-      itemView.title.text = article.title
-
-      val date = SimpleDateFormat("yyyy-MM-dd'T'HH:mm:ss", Locale.getDefault()).parse(article.publishedAt)
-      itemView.publishedAt.text = SimpleDateFormat("yyyy-MM-dd HH:mm", Locale.getDefault()).format(date)
-      itemView.description.text = article.description
+    override fun onCreateViewHolder(parent: ViewGroup, pos: Int): ViewHolder {
+        val view = LayoutInflater.from(parent.context)
+                .inflate(R.layout.item_article, parent, false)
+        return ViewHolder(view)
     }
-  }
+
+    override fun onBindViewHolder(holder: ViewHolder, pos: Int) {
+        holder.bind(articles[pos])
+    }
+
+    override fun getItemCount() = articles.size
+
+    class ViewHolder(view: View) : RecyclerView.ViewHolder(view) {
+
+        fun bind(article: Article) {
+            itemView.picture.load(article.urlToImage)
+            itemView.title.text = article.title
+
+            val date = SimpleDateFormat("yyyy-MM-dd'T'HH:mm:ss", Locale.getDefault()).parse(article.publishedAt)
+            itemView.publishedAt.text = SimpleDateFormat("yyyy-MM-dd HH:mm", Locale.getDefault()).format(date)
+            itemView.description.text = article.description
+        }
+    }
 }

--- a/app/src/main/java/me/jorgecastillo/hiroaki/NewsAdapter.kt
+++ b/app/src/main/java/me/jorgecastillo/hiroaki/NewsAdapter.kt
@@ -1,44 +1,40 @@
 package me.jorgecastillo.hiroaki
 
-import android.support.v7.widget.RecyclerView
 import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
-import kotlinx.android.synthetic.main.item_article.view.description
-import kotlinx.android.synthetic.main.item_article.view.picture
-import kotlinx.android.synthetic.main.item_article.view.publishedAt
-import kotlinx.android.synthetic.main.item_article.view.title
+import androidx.recyclerview.widget.RecyclerView
+import kotlinx.android.synthetic.main.item_article.view.*
 import me.jorgecastillo.hiroaki.NewsAdapter.ViewHolder
 import me.jorgecastillo.hiroaki.model.Article
 import java.text.SimpleDateFormat
 import java.util.Locale
+import kotlin.collections.ArrayList
 
 class NewsAdapter(var articles: List<Article> = ArrayList()) :
-        RecyclerView.Adapter<ViewHolder>() {
+    RecyclerView.Adapter<ViewHolder>() {
 
-    override fun onCreateViewHolder(parent: ViewGroup, pos: Int): ViewHolder {
-        val view = LayoutInflater.from(parent.context)
-                .inflate(R.layout.item_article, parent, false)
-        return ViewHolder(view)
+  override fun onCreateViewHolder(parent: ViewGroup, pos: Int): ViewHolder {
+    val view = LayoutInflater.from(parent.context)
+        .inflate(R.layout.item_article, parent, false)
+    return ViewHolder(view)
+  }
+
+  override fun onBindViewHolder(holder: ViewHolder, pos: Int) {
+    holder.bind(articles[pos])
+  }
+
+  override fun getItemCount() = articles.size
+
+  class ViewHolder(view: View) : RecyclerView.ViewHolder(view) {
+
+    fun bind(article: Article) {
+      itemView.picture.load(article.urlToImage)
+      itemView.title.text = article.title
+
+      val date = SimpleDateFormat("yyyy-MM-dd'T'HH:mm:ss", Locale.getDefault()).parse(article.publishedAt)
+      itemView.publishedAt.text = SimpleDateFormat("yyyy-MM-dd HH:mm", Locale.getDefault()).format(date)
+      itemView.description.text = article.description
     }
-
-    override fun onBindViewHolder(holder: ViewHolder, pos: Int) {
-        holder.bind(articles[pos])
-    }
-
-    override fun getItemCount() = articles.size
-
-    class ViewHolder(view: View) : RecyclerView.ViewHolder(view) {
-
-        fun bind(article: Article) {
-            with(article) {
-                itemView.picture.load(article.urlToImage)
-                itemView.title.text = article.title
-
-                val date = SimpleDateFormat("yyyy-MM-dd'T'HH:mm:ss", Locale.getDefault()).parse(article.publishedAt)
-                itemView.publishedAt.text = SimpleDateFormat("yyyy-MM-dd HH:mm", Locale.getDefault()).format(date)
-                itemView.description.text = article.description
-            }
-        }
-    }
+  }
 }

--- a/app/src/main/java/me/jorgecastillo/hiroaki/SampleApp.kt
+++ b/app/src/main/java/me/jorgecastillo/hiroaki/SampleApp.kt
@@ -1,14 +1,14 @@
 package me.jorgecastillo.hiroaki
 
 import android.app.Activity
-import android.support.multidex.MultiDexApplication
+import androidx.multidex.MultiDexApplication
 import me.jorgecastillo.hiroaki.data.service.MoshiNewsApiService
 import me.jorgecastillo.hiroaki.di.provideNewsService
 
 open class SampleApp : MultiDexApplication() {
 
-    open fun newsService(): MoshiNewsApiService =
-        provideNewsService()
+  open fun newsService(): MoshiNewsApiService =
+      provideNewsService()
 }
 
 fun Activity.getApp() = application as SampleApp

--- a/app/src/main/java/me/jorgecastillo/hiroaki/SampleApp.kt
+++ b/app/src/main/java/me/jorgecastillo/hiroaki/SampleApp.kt
@@ -7,8 +7,8 @@ import me.jorgecastillo.hiroaki.di.provideNewsService
 
 open class SampleApp : MultiDexApplication() {
 
-  open fun newsService(): MoshiNewsApiService =
-      provideNewsService()
+    open fun newsService(): MoshiNewsApiService =
+            provideNewsService()
 }
 
 fun Activity.getApp() = application as SampleApp

--- a/app/src/main/java/me/jorgecastillo/hiroaki/ViewExtensions.kt
+++ b/app/src/main/java/me/jorgecastillo/hiroaki/ViewExtensions.kt
@@ -4,5 +4,5 @@ import android.widget.ImageView
 import com.squareup.picasso.Picasso
 
 fun ImageView.load(url: String) {
-    Picasso.with(context).load(url).into(this)
+  Picasso.get().load(url).into(this)
 }

--- a/app/src/main/java/me/jorgecastillo/hiroaki/ViewExtensions.kt
+++ b/app/src/main/java/me/jorgecastillo/hiroaki/ViewExtensions.kt
@@ -4,5 +4,5 @@ import android.widget.ImageView
 import com.squareup.picasso.Picasso
 
 fun ImageView.load(url: String) {
-  Picasso.get().load(url).into(this)
+    Picasso.get().load(url).into(this)
 }

--- a/app/src/main/java/me/jorgecastillo/hiroaki/data/datasource/GsonNewsNetworkDataSource.kt
+++ b/app/src/main/java/me/jorgecastillo/hiroaki/data/datasource/GsonNewsNetworkDataSource.kt
@@ -14,30 +14,30 @@ import java.io.IOException
  */
 class GsonNewsNetworkDataSource(private val service: GsonNewsApiService) {
 
-  @Throws(IOException::class)
-  suspend fun getNews(): List<Article> {
-    val query = GlobalScope.async(Dispatchers.IO) {
-      val response = service.getNews().execute()
-      if (response.isSuccessful) {
-        response.body()!!.articles.map { it.toArticle() }
-      } else throw IOException("News not found.")
+    @Throws(IOException::class)
+    suspend fun getNews(): List<Article> {
+        val query = GlobalScope.async(Dispatchers.IO) {
+            val response = service.getNews().execute()
+            if (response.isSuccessful) {
+                response.body()!!.articles.map { it.toArticle() }
+            } else throw IOException("News not found.")
+        }
+
+        return query.await()
     }
 
-    return query.await()
-  }
+    /**
+     * This is a no-op method on the real news API, just created for testing purposes.
+     */
+    @Throws(IOException::class)
+    suspend fun publishHeadline(article: Article) {
+        val query = GlobalScope.async(Dispatchers.IO) {
+            val response = service.publishHeadline(article.toGsonDto()).execute()
+            if (!response.isSuccessful) {
+                throw IOException("Coins not found.")
+            }
+        }
 
-  /**
-   * This is a no-op method on the real news API, just created for testing purposes.
-   */
-  @Throws(IOException::class)
-  suspend fun publishHeadline(article: Article) {
-    val query = GlobalScope.async(Dispatchers.IO) {
-      val response = service.publishHeadline(article.toGsonDto()).execute()
-      if (!response.isSuccessful) {
-        throw IOException("Coins not found.")
-      }
+        return query.await()
     }
-
-    return query.await()
-  }
 }

--- a/app/src/main/java/me/jorgecastillo/hiroaki/data/datasource/GsonNewsNetworkDataSource.kt
+++ b/app/src/main/java/me/jorgecastillo/hiroaki/data/datasource/GsonNewsNetworkDataSource.kt
@@ -1,8 +1,5 @@
 package me.jorgecastillo.hiroaki.data.datasource
 
-import kotlinx.coroutines.Dispatchers
-import kotlinx.coroutines.GlobalScope
-import kotlinx.coroutines.async
 import me.jorgecastillo.hiroaki.data.networkdto.toArticle
 import me.jorgecastillo.hiroaki.data.networkdto.toGsonDto
 import me.jorgecastillo.hiroaki.data.service.GsonNewsApiService
@@ -15,29 +12,21 @@ import java.io.IOException
 class GsonNewsNetworkDataSource(private val service: GsonNewsApiService) {
 
     @Throws(IOException::class)
-    suspend fun getNews(): List<Article> {
-        val query = GlobalScope.async(Dispatchers.IO) {
-            val response = service.getNews().execute()
-            if (response.isSuccessful) {
-                response.body()!!.articles.map { it.toArticle() }
-            } else throw IOException("News not found.")
-        }
-
-        return query.await()
+    fun getNews(): List<Article> {
+        val response = service.getNews().execute()
+        if (response.isSuccessful) {
+            return response.body()!!.articles.map { it.toArticle() }
+        } else throw IOException("News not found.")
     }
 
     /**
      * This is a no-op method on the real news API, just created for testing purposes.
      */
     @Throws(IOException::class)
-    suspend fun publishHeadline(article: Article) {
-        val query = GlobalScope.async(Dispatchers.IO) {
-            val response = service.publishHeadline(article.toGsonDto()).execute()
-            if (!response.isSuccessful) {
-                throw IOException("Coins not found.")
-            }
+    fun publishHeadline(article: Article) {
+        val response = service.publishHeadline(article.toGsonDto()).execute()
+        if (!response.isSuccessful) {
+            throw IOException("Coins not found.")
         }
-
-        return query.await()
     }
 }

--- a/app/src/main/java/me/jorgecastillo/hiroaki/data/datasource/GsonNewsNetworkDataSource.kt
+++ b/app/src/main/java/me/jorgecastillo/hiroaki/data/datasource/GsonNewsNetworkDataSource.kt
@@ -1,11 +1,12 @@
 package me.jorgecastillo.hiroaki.data.datasource
 
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.GlobalScope
+import kotlinx.coroutines.async
 import me.jorgecastillo.hiroaki.data.networkdto.toArticle
 import me.jorgecastillo.hiroaki.data.networkdto.toGsonDto
 import me.jorgecastillo.hiroaki.data.service.GsonNewsApiService
 import me.jorgecastillo.hiroaki.model.Article
-import kotlinx.coroutines.experimental.CommonPool
-import kotlinx.coroutines.experimental.async
 import java.io.IOException
 
 /**
@@ -13,30 +14,30 @@ import java.io.IOException
  */
 class GsonNewsNetworkDataSource(private val service: GsonNewsApiService) {
 
-    @Throws(IOException::class)
-    suspend fun getNews(): List<Article> {
-        val query = async(CommonPool) {
-            val response = service.getNews().execute()
-            if (response.isSuccessful) {
-                response.body()!!.articles.map { it.toArticle() }
-            } else throw IOException("News not found.")
-        }
-
-        return query.await()
+  @Throws(IOException::class)
+  suspend fun getNews(): List<Article> {
+    val query = GlobalScope.async(Dispatchers.IO) {
+      val response = service.getNews().execute()
+      if (response.isSuccessful) {
+        response.body()!!.articles.map { it.toArticle() }
+      } else throw IOException("News not found.")
     }
 
-    /**
-     * This is a no-op method on the real news API, just created for testing purposes.
-     */
-    @Throws(IOException::class)
-    suspend fun publishHeadline(article: Article) {
-        val query = async(CommonPool) {
-            val response = service.publishHeadline(article.toGsonDto()).execute()
-            if (!response.isSuccessful) {
-                throw IOException("Coins not found.")
-            }
-        }
+    return query.await()
+  }
 
-        return query.await()
+  /**
+   * This is a no-op method on the real news API, just created for testing purposes.
+   */
+  @Throws(IOException::class)
+  suspend fun publishHeadline(article: Article) {
+    val query = GlobalScope.async(Dispatchers.IO) {
+      val response = service.publishHeadline(article.toGsonDto()).execute()
+      if (!response.isSuccessful) {
+        throw IOException("Coins not found.")
+      }
     }
+
+    return query.await()
+  }
 }

--- a/app/src/main/java/me/jorgecastillo/hiroaki/data/datasource/JacksonNewsNetworkDataSource.kt
+++ b/app/src/main/java/me/jorgecastillo/hiroaki/data/datasource/JacksonNewsNetworkDataSource.kt
@@ -1,11 +1,12 @@
 package me.jorgecastillo.hiroaki.data.datasource
 
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.GlobalScope
+import kotlinx.coroutines.async
 import me.jorgecastillo.hiroaki.data.networkdto.toArticle
 import me.jorgecastillo.hiroaki.data.networkdto.toJacksonDto
 import me.jorgecastillo.hiroaki.data.service.JacksonNewsApiService
 import me.jorgecastillo.hiroaki.model.Article
-import kotlinx.coroutines.experimental.CommonPool
-import kotlinx.coroutines.experimental.async
 import java.io.IOException
 
 /**
@@ -13,30 +14,30 @@ import java.io.IOException
  */
 class JacksonNewsNetworkDataSource(private val service: JacksonNewsApiService) {
 
-    @Throws(IOException::class)
-    suspend fun getNews(): List<Article> {
-        val query = async(CommonPool) {
-            val response = service.getNews().execute()
-            if (response.isSuccessful) {
-                response.body()!!.articles.map { it.toArticle() }
-            } else throw IOException("Coins not found.")
-        }
-
-        return query.await()
+  @Throws(IOException::class)
+  suspend fun getNews(): List<Article> {
+    val query = GlobalScope.async(Dispatchers.IO) {
+      val response = service.getNews().execute()
+      if (response.isSuccessful) {
+        response.body()!!.articles.map { it.toArticle() }
+      } else throw IOException("Coins not found.")
     }
 
-    /**
-     * This is a no-op method on the real news API, just created for testing purposes.
-     */
-    @Throws(IOException::class)
-    suspend fun publishHeadline(article: Article) {
-        val query = async(CommonPool) {
-            val response = service.publishHeadline(article.toJacksonDto()).execute()
-            if (!response.isSuccessful) {
-                throw IOException("Coins not found.")
-            }
-        }
+    return query.await()
+  }
 
-        return query.await()
+  /**
+   * This is a no-op method on the real news API, just created for testing purposes.
+   */
+  @Throws(IOException::class)
+  suspend fun publishHeadline(article: Article) {
+    val query = GlobalScope.async(Dispatchers.IO) {
+      val response = service.publishHeadline(article.toJacksonDto()).execute()
+      if (!response.isSuccessful) {
+        throw IOException("Coins not found.")
+      }
     }
+
+    return query.await()
+  }
 }

--- a/app/src/main/java/me/jorgecastillo/hiroaki/data/datasource/JacksonNewsNetworkDataSource.kt
+++ b/app/src/main/java/me/jorgecastillo/hiroaki/data/datasource/JacksonNewsNetworkDataSource.kt
@@ -1,8 +1,5 @@
 package me.jorgecastillo.hiroaki.data.datasource
 
-import kotlinx.coroutines.Dispatchers
-import kotlinx.coroutines.GlobalScope
-import kotlinx.coroutines.async
 import me.jorgecastillo.hiroaki.data.networkdto.toArticle
 import me.jorgecastillo.hiroaki.data.networkdto.toJacksonDto
 import me.jorgecastillo.hiroaki.data.service.JacksonNewsApiService
@@ -15,29 +12,21 @@ import java.io.IOException
 class JacksonNewsNetworkDataSource(private val service: JacksonNewsApiService) {
 
     @Throws(IOException::class)
-    suspend fun getNews(): List<Article> {
-        val query = GlobalScope.async(Dispatchers.IO) {
-            val response = service.getNews().execute()
-            if (response.isSuccessful) {
-                response.body()!!.articles.map { it.toArticle() }
-            } else throw IOException("Coins not found.")
-        }
-
-        return query.await()
+    fun getNews(): List<Article> {
+        val response = service.getNews().execute()
+        if (response.isSuccessful) {
+            return response.body()!!.articles.map { it.toArticle() }
+        } else throw IOException("Coins not found.")
     }
 
     /**
      * This is a no-op method on the real news API, just created for testing purposes.
      */
     @Throws(IOException::class)
-    suspend fun publishHeadline(article: Article) {
-        val query = GlobalScope.async(Dispatchers.IO) {
-            val response = service.publishHeadline(article.toJacksonDto()).execute()
-            if (!response.isSuccessful) {
-                throw IOException("Coins not found.")
-            }
+    fun publishHeadline(article: Article) {
+        val response = service.publishHeadline(article.toJacksonDto()).execute()
+        if (!response.isSuccessful) {
+            throw IOException("Coins not found.")
         }
-
-        return query.await()
     }
 }

--- a/app/src/main/java/me/jorgecastillo/hiroaki/data/datasource/JacksonNewsNetworkDataSource.kt
+++ b/app/src/main/java/me/jorgecastillo/hiroaki/data/datasource/JacksonNewsNetworkDataSource.kt
@@ -14,30 +14,30 @@ import java.io.IOException
  */
 class JacksonNewsNetworkDataSource(private val service: JacksonNewsApiService) {
 
-  @Throws(IOException::class)
-  suspend fun getNews(): List<Article> {
-    val query = GlobalScope.async(Dispatchers.IO) {
-      val response = service.getNews().execute()
-      if (response.isSuccessful) {
-        response.body()!!.articles.map { it.toArticle() }
-      } else throw IOException("Coins not found.")
+    @Throws(IOException::class)
+    suspend fun getNews(): List<Article> {
+        val query = GlobalScope.async(Dispatchers.IO) {
+            val response = service.getNews().execute()
+            if (response.isSuccessful) {
+                response.body()!!.articles.map { it.toArticle() }
+            } else throw IOException("Coins not found.")
+        }
+
+        return query.await()
     }
 
-    return query.await()
-  }
+    /**
+     * This is a no-op method on the real news API, just created for testing purposes.
+     */
+    @Throws(IOException::class)
+    suspend fun publishHeadline(article: Article) {
+        val query = GlobalScope.async(Dispatchers.IO) {
+            val response = service.publishHeadline(article.toJacksonDto()).execute()
+            if (!response.isSuccessful) {
+                throw IOException("Coins not found.")
+            }
+        }
 
-  /**
-   * This is a no-op method on the real news API, just created for testing purposes.
-   */
-  @Throws(IOException::class)
-  suspend fun publishHeadline(article: Article) {
-    val query = GlobalScope.async(Dispatchers.IO) {
-      val response = service.publishHeadline(article.toJacksonDto()).execute()
-      if (!response.isSuccessful) {
-        throw IOException("Coins not found.")
-      }
+        return query.await()
     }
-
-    return query.await()
-  }
 }

--- a/app/src/main/java/me/jorgecastillo/hiroaki/data/datasource/MoshiNewsNetworkDataSource.kt
+++ b/app/src/main/java/me/jorgecastillo/hiroaki/data/datasource/MoshiNewsNetworkDataSource.kt
@@ -14,30 +14,30 @@ import java.io.IOException
  */
 class MoshiNewsNetworkDataSource(private val service: MoshiNewsApiService) {
 
-  @Throws(IOException::class)
-  suspend fun getNews(): List<Article> {
-    val query = GlobalScope.async(Dispatchers.IO) {
-      val response = service.getNews().execute()
-      if (response.isSuccessful) {
-        response.body()!!.articles.map { it.toArticle() }
-      } else throw IOException("Coins not found.")
+    @Throws(IOException::class)
+    suspend fun getNews(): List<Article> {
+        val query = GlobalScope.async(Dispatchers.IO) {
+            val response = service.getNews().execute()
+            if (response.isSuccessful) {
+                response.body()!!.articles.map { it.toArticle() }
+            } else throw IOException("Coins not found.")
+        }
+
+        return query.await()
     }
 
-    return query.await()
-  }
+    /**
+     * This is a no-op method on the real news API, just created for testing purposes.
+     */
+    @Throws(IOException::class)
+    suspend fun publishHeadline(article: Article) {
+        val query = GlobalScope.async(Dispatchers.IO) {
+            val response = service.publishHeadline(article.toMoshiDto()).execute()
+            if (!response.isSuccessful) {
+                throw IOException("Coins not found.")
+            }
+        }
 
-  /**
-   * This is a no-op method on the real news API, just created for testing purposes.
-   */
-  @Throws(IOException::class)
-  suspend fun publishHeadline(article: Article) {
-    val query = GlobalScope.async(Dispatchers.IO) {
-      val response = service.publishHeadline(article.toMoshiDto()).execute()
-      if (!response.isSuccessful) {
-        throw IOException("Coins not found.")
-      }
+        return query.await()
     }
-
-    return query.await()
-  }
 }

--- a/app/src/main/java/me/jorgecastillo/hiroaki/data/datasource/MoshiNewsNetworkDataSource.kt
+++ b/app/src/main/java/me/jorgecastillo/hiroaki/data/datasource/MoshiNewsNetworkDataSource.kt
@@ -1,11 +1,12 @@
 package me.jorgecastillo.hiroaki.data.datasource
 
-import me.jorgecastillo.hiroaki.data.service.MoshiNewsApiService
-import me.jorgecastillo.hiroaki.model.Article
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.GlobalScope
+import kotlinx.coroutines.async
 import me.jorgecastillo.hiroaki.data.networkdto.toArticle
 import me.jorgecastillo.hiroaki.data.networkdto.toMoshiDto
-import kotlinx.coroutines.experimental.CommonPool
-import kotlinx.coroutines.experimental.async
+import me.jorgecastillo.hiroaki.data.service.MoshiNewsApiService
+import me.jorgecastillo.hiroaki.model.Article
 import java.io.IOException
 
 /**
@@ -13,30 +14,30 @@ import java.io.IOException
  */
 class MoshiNewsNetworkDataSource(private val service: MoshiNewsApiService) {
 
-    @Throws(IOException::class)
-    suspend fun getNews(): List<Article> {
-        val query = async(CommonPool) {
-            val response = service.getNews().execute()
-            if (response.isSuccessful) {
-                response.body()!!.articles.map { it.toArticle() }
-            } else throw IOException("Coins not found.")
-        }
-
-        return query.await()
+  @Throws(IOException::class)
+  suspend fun getNews(): List<Article> {
+    val query = GlobalScope.async(Dispatchers.IO) {
+      val response = service.getNews().execute()
+      if (response.isSuccessful) {
+        response.body()!!.articles.map { it.toArticle() }
+      } else throw IOException("Coins not found.")
     }
 
-    /**
-     * This is a no-op method on the real news API, just created for testing purposes.
-     */
-    @Throws(IOException::class)
-    suspend fun publishHeadline(article: Article) {
-        val query = async(CommonPool) {
-            val response = service.publishHeadline(article.toMoshiDto()).execute()
-            if (!response.isSuccessful) {
-                throw IOException("Coins not found.")
-            }
-        }
+    return query.await()
+  }
 
-        return query.await()
+  /**
+   * This is a no-op method on the real news API, just created for testing purposes.
+   */
+  @Throws(IOException::class)
+  suspend fun publishHeadline(article: Article) {
+    val query = GlobalScope.async(Dispatchers.IO) {
+      val response = service.publishHeadline(article.toMoshiDto()).execute()
+      if (!response.isSuccessful) {
+        throw IOException("Coins not found.")
+      }
     }
+
+    return query.await()
+  }
 }

--- a/app/src/main/java/me/jorgecastillo/hiroaki/data/datasource/MoshiNewsNetworkDataSource.kt
+++ b/app/src/main/java/me/jorgecastillo/hiroaki/data/datasource/MoshiNewsNetworkDataSource.kt
@@ -1,8 +1,5 @@
 package me.jorgecastillo.hiroaki.data.datasource
 
-import kotlinx.coroutines.Dispatchers
-import kotlinx.coroutines.GlobalScope
-import kotlinx.coroutines.async
 import me.jorgecastillo.hiroaki.data.networkdto.toArticle
 import me.jorgecastillo.hiroaki.data.networkdto.toMoshiDto
 import me.jorgecastillo.hiroaki.data.service.MoshiNewsApiService
@@ -15,29 +12,21 @@ import java.io.IOException
 class MoshiNewsNetworkDataSource(private val service: MoshiNewsApiService) {
 
     @Throws(IOException::class)
-    suspend fun getNews(): List<Article> {
-        val query = GlobalScope.async(Dispatchers.IO) {
-            val response = service.getNews().execute()
-            if (response.isSuccessful) {
-                response.body()!!.articles.map { it.toArticle() }
-            } else throw IOException("Coins not found.")
-        }
-
-        return query.await()
+    fun getNews(): List<Article> {
+        val response = service.getNews().execute()
+        if (response.isSuccessful) {
+            return response.body()!!.articles.map { it.toArticle() }
+        } else throw IOException("Coins not found.")
     }
 
     /**
      * This is a no-op method on the real news API, just created for testing purposes.
      */
     @Throws(IOException::class)
-    suspend fun publishHeadline(article: Article) {
-        val query = GlobalScope.async(Dispatchers.IO) {
-            val response = service.publishHeadline(article.toMoshiDto()).execute()
-            if (!response.isSuccessful) {
-                throw IOException("Coins not found.")
-            }
+    fun publishHeadline(article: Article) {
+        val response = service.publishHeadline(article.toMoshiDto()).execute()
+        if (!response.isSuccessful) {
+            throw IOException("Coins not found.")
         }
-
-        return query.await()
     }
 }

--- a/app/src/main/java/me/jorgecastillo/hiroaki/data/networkdto/MoshiArticleDto.kt
+++ b/app/src/main/java/me/jorgecastillo/hiroaki/data/networkdto/MoshiArticleDto.kt
@@ -24,7 +24,7 @@ fun MoshiArticleDto.toArticle() =
     Article(title, description, url, urlToImage, publishedAt, source.toSource())
 
 fun Article.toMoshiDto() = MoshiArticleDto(
-        title, description, url, urlToImage, publishedAt, source.toMoshiDto()
+    title, description, url, urlToImage, publishedAt, source.toMoshiDto()
 )
 
 fun MoshiSourceDto.toSource() = Source(id, name)

--- a/app/src/main/res/layout/activity_main.xml
+++ b/app/src/main/res/layout/activity_main.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<android.support.constraint.ConstraintLayout
+<androidx.constraintlayout.widget.ConstraintLayout
     xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:app="http://schemas.android.com/apk/res-auto"
     android:layout_width="match_parent"
@@ -7,7 +7,7 @@
     android:background="#ffffff"
     >
 
-    <android.support.v7.widget.Toolbar
+    <androidx.appcompat.widget.Toolbar
         android:id="@+id/toolbar"
         android:layout_width="0dp"
         android:layout_height="?attr/actionBarSize"
@@ -18,7 +18,7 @@
         app:layout_constraintTop_toTopOf="parent"
         app:popupTheme="@style/AppTheme.PopupOverlay"/>
 
-    <android.support.v7.widget.RecyclerView
+    <androidx.recyclerview.widget.RecyclerView
         android:id="@+id/newsList"
         android:layout_width="0dp"
         android:layout_height="0dp"
@@ -46,4 +46,4 @@
         app:layout_constraintTop_toTopOf="parent"
         />
 
-</android.support.constraint.ConstraintLayout>
+</androidx.constraintlayout.widget.ConstraintLayout>

--- a/app/src/main/res/layout/content_main.xml
+++ b/app/src/main/res/layout/content_main.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<android.support.constraint.ConstraintLayout
+<androidx.constraintlayout.widget.ConstraintLayout
     xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:app="http://schemas.android.com/apk/res-auto"
     xmlns:tools="http://schemas.android.com/tools"
@@ -18,4 +18,4 @@
         app:layout_constraintRight_toRightOf="parent"
         app:layout_constraintTop_toTopOf="parent"/>
 
-</android.support.constraint.ConstraintLayout>
+</androidx.constraintlayout.widget.ConstraintLayout>

--- a/app/src/main/res/layout/item_article.xml
+++ b/app/src/main/res/layout/item_article.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<android.support.v7.widget.CardView
+<androidx.cardview.widget.CardView
     xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:tools="http://schemas.android.com/tools"
     android:layout_width="match_parent"
@@ -60,4 +60,4 @@
         tools:text="Asokda odasko daoskdas kopdsakopd akopsdk oadopkask doasdkop asdkpoasd"
         />
   </LinearLayout>
-</android.support.v7.widget.CardView>
+</androidx.cardview.widget.CardView>

--- a/app/src/test/java/me/jorgecastillo/hiroaki/GsonNewsNetworkDataSourceTest.kt
+++ b/app/src/test/java/me/jorgecastillo/hiroaki/GsonNewsNetworkDataSourceTest.kt
@@ -24,115 +24,115 @@ import java.io.IOException
 @RunWith(MockitoJUnitRunner::class)
 class GsonNewsNetworkDataSourceTest : MockServerSuite() {
 
-  private lateinit var dataSource: GsonNewsNetworkDataSource
+    private lateinit var dataSource: GsonNewsNetworkDataSource
 
-  @Before
-  override fun setup() {
-    super.setup()
-    dataSource = GsonNewsNetworkDataSource(
-        server.retrofitService(
-            GsonNewsApiService::class.java,
-            GsonConverterFactory.create()
+    @Before
+    override fun setup() {
+        super.setup()
+        dataSource = GsonNewsNetworkDataSource(
+            server.retrofitService(
+                GsonNewsApiService::class.java,
+                GsonConverterFactory.create()
+            )
         )
-    )
-  }
+    }
 
-  @Test
-  fun sendsGetNews() {
-    server.whenever(GET, "v2/top-headlines")
-        .thenRespond(success(jsonBody = fileBody("GetNews.json")))
+    @Test
+    fun sendsGetNews() {
+        server.whenever(GET, "v2/top-headlines")
+            .thenRespond(success(jsonBody = fileBody("GetNews.json")))
 
-    runBlocking { dataSource.getNews() }
+        runBlocking { dataSource.getNews() }
 
-    server.verify("v2/top-headlines").called(
-        times = times(1),
-        queryParams = params(
-            "sources" to "crypto-coins-news",
-            "apiKey" to "a7c816f57c004c49a21bd458e11e2807"),
-        headers = headers(
-            "Cache-Control" to "max-age=640000"
-        ),
-        method = GET)
-  }
+        server.verify("v2/top-headlines").called(
+            times = times(1),
+            queryParams = params(
+                "sources" to "crypto-coins-news",
+                "apiKey" to "a7c816f57c004c49a21bd458e11e2807"),
+            headers = headers(
+                "Cache-Control" to "max-age=640000"
+            ),
+            method = GET)
+    }
 
-  @Test
-  fun sendsPublishHeadline() {
-    server.whenever(POST, "v2/top-headlines").thenRespond(success())
-    val article = anyArticle()
+    @Test
+    fun sendsPublishHeadline() {
+        server.whenever(POST, "v2/top-headlines").thenRespond(success())
+        val article = anyArticle()
 
-    runBlocking { dataSource.publishHeadline(article) }
+        runBlocking { dataSource.publishHeadline(article) }
 
-    server.verify("v2/top-headlines").called(
-        times = once(),
-        jsonBody = fileBody("PublishHeadline.json"),
-        method = POST)
-  }
+        server.verify("v2/top-headlines").called(
+            times = once(),
+            jsonBody = fileBody("PublishHeadline.json"),
+            method = POST)
+    }
 
-  @Test
-  fun sendsPublishHeadlineUsingInlineBody() {
-    server.whenever(POST, "v2/top-headlines").thenRespond(success())
-    val article = anyArticle()
+    @Test
+    fun sendsPublishHeadlineUsingInlineBody() {
+        server.whenever(POST, "v2/top-headlines").thenRespond(success())
+        val article = anyArticle()
 
-    runBlocking { dataSource.publishHeadline(article) }
+        runBlocking { dataSource.publishHeadline(article) }
 
-    server.verify("v2/top-headlines").called(
-        times = once(),
-        jsonBody = inlineBody("{\n" +
-            "  \"title\": \"Any Title\",\n" +
-            "  \"description\": \"Any description\",\n" +
-            "  \"url\": \"http://any.url\",\n" +
-            "  \"urlToImage\": \"http://any.url/any_image.png\",\n" +
-            "  \"publishedAt\": \"2018-03-10T14:09:00Z\",\n" +
-            "  \"source\": {\n" +
-            "    \"id\": \"AnyId\",\n" +
-            "    \"name\": \"ANYID\"\n" +
-            "  }\n" +
-            "}\n"))
-  }
+        server.verify("v2/top-headlines").called(
+            times = once(),
+            jsonBody = inlineBody("{\n" +
+                "  \"title\": \"Any Title\",\n" +
+                "  \"description\": \"Any description\",\n" +
+                "  \"url\": \"http://any.url\",\n" +
+                "  \"urlToImage\": \"http://any.url/any_image.png\",\n" +
+                "  \"publishedAt\": \"2018-03-10T14:09:00Z\",\n" +
+                "  \"source\": {\n" +
+                "    \"id\": \"AnyId\",\n" +
+                "    \"name\": \"ANYID\"\n" +
+                "  }\n" +
+                "}\n"))
+    }
 
-  @Test
-  fun parsesNewsProperly() {
-    server.whenever(GET, "v2/top-headlines")
-        .thenRespond(success(jsonBody = fileBody("GetNews.json")))
+    @Test
+    fun parsesNewsProperly() {
+        server.whenever(GET, "v2/top-headlines")
+            .thenRespond(success(jsonBody = fileBody("GetNews.json")))
 
-    val news = runBlocking { dataSource.getNews() }
+        val news = runBlocking { dataSource.getNews() }
 
-    news eq expectedNews()
-  }
+        news eq expectedNews()
+    }
 
-  @Test(expected = IOException::class)
-  fun throwsIOExceptionOnGetNewsErrorResponse() {
-    server.whenever(GET, "v2/top-headlines").thenRespond(error())
+    @Test(expected = IOException::class)
+    fun throwsIOExceptionOnGetNewsErrorResponse() {
+        server.whenever(GET, "v2/top-headlines").thenRespond(error())
 
-    runBlocking { dataSource.getNews() }
-  }
+        runBlocking { dataSource.getNews() }
+    }
 
-  private fun expectedNews(): List<Article> {
-    return listOf(
-        Article(
-            "How to Get Android P's Screenshot Editing Tool on Any Android Phone",
-            "Last year, Apple brought advanced screenshot editing tools to the iPhone with iOS 11, and, this week, Google fired back with a similar Android feature called Markup. The only catch is that this new tool is limited to Android P, which launches later this year …",
-            "https://lifehacker.com/how-to-get-android-ps-screenshot-editing-tool-on-any-an-1823646122",
-            "https://i.kinja-img.com/gawker-media/image/upload/s--Y-5X_NcT--/c_fill,fl_progressive,g_center,h_450,q_80,w_800/nxmwbkwzoc1z1tmak7s4.jpg",
-            "2018-03-09T20:30:00Z",
-            Source(null, "Lifehacker.com")
-        ),
-        Article(
-            "Capital One's virtual credit cards could help you avoid fraud",
-            "Capital One is no stranger to trying new things -- especially when it comes to technology. Its Eno texting chatbot, for example, is a quick and conversational way for its customers to check their balances and perform simple tasks, like checking on recent tran…",
-            "https://www.engadget.com/2018/03/09/capital-one-virtual-credit-cards/",
-            "https://o.aolcdn.com/images/dims?thumbnail=1200%2C630&quality=80&image_uri=https%3A%2F%2Fo.aolcdn.com%2Fimages%2Fdims%3Fcrop%3D3861%252C2574%252C0%252C0%26quality%3D85%26format%3Djpg%26resize%3D1600%252C1067%26image_uri%3Dhttp%253A%252F%252Fo.aolcdn.com%252Fhss%252Fstorage%252Fmidas%252Fca9d74d8d57677d4f3291ae4347b26da%252F206197048%252Fcapital-one-financial-corp-signage-is-displayed-at-a-bank-branch-in-picture-id120933061%26client%3Da1acac3e1b3290917d92%26signature%3Db51d9958f8487452f6a8c6d354650fcb339f0520&client=cbc79c14efcebee57402&signature=44e59feb505c1b9c4e5867d453d3ed345010acac",
-            "2018-03-09T13:00:00Z",
-            Source("engadget", "Engadget")
-        ),
-        Article(
-            "Magic Leap gets \$461M more, Travis goes VC, and HQ Trivia scales up",
-            "Hello and welcome back to Equity, TechCrunch’s venture capital-focused podcast where we unpack the numbers behind the headlines. This week we had a corking set of news to get through, so we rounded up the usual gang (Matthew Lynley, Katie Roof, and myself), a…",
-            "http://techcrunch.com/2018/03/09/magic-leap-gets-461m-more-travis-goes-vc-and-hq-trivia-scales-up/",
-            "https://tctechcrunch2011.files.wordpress.com/2017/03/tc-equity-podcast-ios.jpg",
-            "2018-03-09T14:10:01Z",
-            Source("techcrunch", "TechCrunch")
+    private fun expectedNews(): List<Article> {
+        return listOf(
+            Article(
+                "How to Get Android P's Screenshot Editing Tool on Any Android Phone",
+                "Last year, Apple brought advanced screenshot editing tools to the iPhone with iOS 11, and, this week, Google fired back with a similar Android feature called Markup. The only catch is that this new tool is limited to Android P, which launches later this year …",
+                "https://lifehacker.com/how-to-get-android-ps-screenshot-editing-tool-on-any-an-1823646122",
+                "https://i.kinja-img.com/gawker-media/image/upload/s--Y-5X_NcT--/c_fill,fl_progressive,g_center,h_450,q_80,w_800/nxmwbkwzoc1z1tmak7s4.jpg",
+                "2018-03-09T20:30:00Z",
+                Source(null, "Lifehacker.com")
+            ),
+            Article(
+                "Capital One's virtual credit cards could help you avoid fraud",
+                "Capital One is no stranger to trying new things -- especially when it comes to technology. Its Eno texting chatbot, for example, is a quick and conversational way for its customers to check their balances and perform simple tasks, like checking on recent tran…",
+                "https://www.engadget.com/2018/03/09/capital-one-virtual-credit-cards/",
+                "https://o.aolcdn.com/images/dims?thumbnail=1200%2C630&quality=80&image_uri=https%3A%2F%2Fo.aolcdn.com%2Fimages%2Fdims%3Fcrop%3D3861%252C2574%252C0%252C0%26quality%3D85%26format%3Djpg%26resize%3D1600%252C1067%26image_uri%3Dhttp%253A%252F%252Fo.aolcdn.com%252Fhss%252Fstorage%252Fmidas%252Fca9d74d8d57677d4f3291ae4347b26da%252F206197048%252Fcapital-one-financial-corp-signage-is-displayed-at-a-bank-branch-in-picture-id120933061%26client%3Da1acac3e1b3290917d92%26signature%3Db51d9958f8487452f6a8c6d354650fcb339f0520&client=cbc79c14efcebee57402&signature=44e59feb505c1b9c4e5867d453d3ed345010acac",
+                "2018-03-09T13:00:00Z",
+                Source("engadget", "Engadget")
+            ),
+            Article(
+                "Magic Leap gets \$461M more, Travis goes VC, and HQ Trivia scales up",
+                "Hello and welcome back to Equity, TechCrunch’s venture capital-focused podcast where we unpack the numbers behind the headlines. This week we had a corking set of news to get through, so we rounded up the usual gang (Matthew Lynley, Katie Roof, and myself), a…",
+                "http://techcrunch.com/2018/03/09/magic-leap-gets-461m-more-travis-goes-vc-and-hq-trivia-scales-up/",
+                "https://tctechcrunch2011.files.wordpress.com/2017/03/tc-equity-podcast-ios.jpg",
+                "2018-03-09T14:10:01Z",
+                Source("techcrunch", "TechCrunch")
+            )
         )
-    )
-  }
+    }
 }

--- a/app/src/test/java/me/jorgecastillo/hiroaki/GsonNewsNetworkDataSourceTest.kt
+++ b/app/src/test/java/me/jorgecastillo/hiroaki/GsonNewsNetworkDataSourceTest.kt
@@ -1,6 +1,6 @@
 package me.jorgecastillo.hiroaki
 
-import kotlinx.coroutines.experimental.runBlocking
+import kotlinx.coroutines.runBlocking
 import me.jorgecastillo.hiroaki.Method.GET
 import me.jorgecastillo.hiroaki.Method.POST
 import me.jorgecastillo.hiroaki.data.datasource.GsonNewsNetworkDataSource
@@ -24,115 +24,115 @@ import java.io.IOException
 @RunWith(MockitoJUnitRunner::class)
 class GsonNewsNetworkDataSourceTest : MockServerSuite() {
 
-    private lateinit var dataSource: GsonNewsNetworkDataSource
+  private lateinit var dataSource: GsonNewsNetworkDataSource
 
-    @Before
-    override fun setup() {
-        super.setup()
-        dataSource = GsonNewsNetworkDataSource(
-                server.retrofitService(
-                        GsonNewsApiService::class.java,
-                        GsonConverterFactory.create()
-                )
+  @Before
+  override fun setup() {
+    super.setup()
+    dataSource = GsonNewsNetworkDataSource(
+        server.retrofitService(
+            GsonNewsApiService::class.java,
+            GsonConverterFactory.create()
         )
-    }
+    )
+  }
 
-    @Test
-    fun sendsGetNews() {
-        server.whenever(GET, "v2/top-headlines")
-                .thenRespond(success(jsonBody = fileBody("GetNews.json")))
+  @Test
+  fun sendsGetNews() {
+    server.whenever(GET, "v2/top-headlines")
+        .thenRespond(success(jsonBody = fileBody("GetNews.json")))
 
-        runBlocking { dataSource.getNews() }
+    runBlocking { dataSource.getNews() }
 
-        server.verify("v2/top-headlines").called(
-                times = times(1),
-                queryParams = params(
-                        "sources" to "crypto-coins-news",
-                        "apiKey" to "a7c816f57c004c49a21bd458e11e2807"),
-                headers = headers(
-                        "Cache-Control" to "max-age=640000"
-                ),
-                method = GET)
-    }
+    server.verify("v2/top-headlines").called(
+        times = times(1),
+        queryParams = params(
+            "sources" to "crypto-coins-news",
+            "apiKey" to "a7c816f57c004c49a21bd458e11e2807"),
+        headers = headers(
+            "Cache-Control" to "max-age=640000"
+        ),
+        method = GET)
+  }
 
-    @Test
-    fun sendsPublishHeadline() {
-        server.whenever(POST, "v2/top-headlines").thenRespond(success())
-        val article = anyArticle()
+  @Test
+  fun sendsPublishHeadline() {
+    server.whenever(POST, "v2/top-headlines").thenRespond(success())
+    val article = anyArticle()
 
-        runBlocking { dataSource.publishHeadline(article) }
+    runBlocking { dataSource.publishHeadline(article) }
 
-        server.verify("v2/top-headlines").called(
-                times = once(),
-                jsonBody = fileBody("PublishHeadline.json"),
-                method = POST)
-    }
+    server.verify("v2/top-headlines").called(
+        times = once(),
+        jsonBody = fileBody("PublishHeadline.json"),
+        method = POST)
+  }
 
-    @Test
-    fun sendsPublishHeadlineUsingInlineBody() {
-        server.whenever(POST, "v2/top-headlines").thenRespond(success())
-        val article = anyArticle()
+  @Test
+  fun sendsPublishHeadlineUsingInlineBody() {
+    server.whenever(POST, "v2/top-headlines").thenRespond(success())
+    val article = anyArticle()
 
-        runBlocking { dataSource.publishHeadline(article) }
+    runBlocking { dataSource.publishHeadline(article) }
 
-        server.verify("v2/top-headlines").called(
-                times = once(),
-                jsonBody = inlineBody("{\n" +
-                        "  \"title\": \"Any Title\",\n" +
-                        "  \"description\": \"Any description\",\n" +
-                        "  \"url\": \"http://any.url\",\n" +
-                        "  \"urlToImage\": \"http://any.url/any_image.png\",\n" +
-                        "  \"publishedAt\": \"2018-03-10T14:09:00Z\",\n" +
-                        "  \"source\": {\n" +
-                        "    \"id\": \"AnyId\",\n" +
-                        "    \"name\": \"ANYID\"\n" +
-                        "  }\n" +
-                        "}\n"))
-    }
+    server.verify("v2/top-headlines").called(
+        times = once(),
+        jsonBody = inlineBody("{\n" +
+            "  \"title\": \"Any Title\",\n" +
+            "  \"description\": \"Any description\",\n" +
+            "  \"url\": \"http://any.url\",\n" +
+            "  \"urlToImage\": \"http://any.url/any_image.png\",\n" +
+            "  \"publishedAt\": \"2018-03-10T14:09:00Z\",\n" +
+            "  \"source\": {\n" +
+            "    \"id\": \"AnyId\",\n" +
+            "    \"name\": \"ANYID\"\n" +
+            "  }\n" +
+            "}\n"))
+  }
 
-    @Test
-    fun parsesNewsProperly() {
-        server.whenever(GET, "v2/top-headlines")
-                .thenRespond(success(jsonBody = fileBody("GetNews.json")))
+  @Test
+  fun parsesNewsProperly() {
+    server.whenever(GET, "v2/top-headlines")
+        .thenRespond(success(jsonBody = fileBody("GetNews.json")))
 
-        val news = runBlocking { dataSource.getNews() }
+    val news = runBlocking { dataSource.getNews() }
 
-        news eq expectedNews()
-    }
+    news eq expectedNews()
+  }
 
-    @Test(expected = IOException::class)
-    fun throwsIOExceptionOnGetNewsErrorResponse() {
-        server.whenever(GET, "v2/top-headlines").thenRespond(error())
+  @Test(expected = IOException::class)
+  fun throwsIOExceptionOnGetNewsErrorResponse() {
+    server.whenever(GET, "v2/top-headlines").thenRespond(error())
 
-        runBlocking { dataSource.getNews() }
-    }
+    runBlocking { dataSource.getNews() }
+  }
 
-    private fun expectedNews(): List<Article> {
-        return listOf(
-                Article(
-                        "How to Get Android P's Screenshot Editing Tool on Any Android Phone",
-                        "Last year, Apple brought advanced screenshot editing tools to the iPhone with iOS 11, and, this week, Google fired back with a similar Android feature called Markup. The only catch is that this new tool is limited to Android P, which launches later this year …",
-                        "https://lifehacker.com/how-to-get-android-ps-screenshot-editing-tool-on-any-an-1823646122",
-                        "https://i.kinja-img.com/gawker-media/image/upload/s--Y-5X_NcT--/c_fill,fl_progressive,g_center,h_450,q_80,w_800/nxmwbkwzoc1z1tmak7s4.jpg",
-                        "2018-03-09T20:30:00Z",
-                        Source(null, "Lifehacker.com")
-                ),
-                Article(
-                        "Capital One's virtual credit cards could help you avoid fraud",
-                        "Capital One is no stranger to trying new things -- especially when it comes to technology. Its Eno texting chatbot, for example, is a quick and conversational way for its customers to check their balances and perform simple tasks, like checking on recent tran…",
-                        "https://www.engadget.com/2018/03/09/capital-one-virtual-credit-cards/",
-                        "https://o.aolcdn.com/images/dims?thumbnail=1200%2C630&quality=80&image_uri=https%3A%2F%2Fo.aolcdn.com%2Fimages%2Fdims%3Fcrop%3D3861%252C2574%252C0%252C0%26quality%3D85%26format%3Djpg%26resize%3D1600%252C1067%26image_uri%3Dhttp%253A%252F%252Fo.aolcdn.com%252Fhss%252Fstorage%252Fmidas%252Fca9d74d8d57677d4f3291ae4347b26da%252F206197048%252Fcapital-one-financial-corp-signage-is-displayed-at-a-bank-branch-in-picture-id120933061%26client%3Da1acac3e1b3290917d92%26signature%3Db51d9958f8487452f6a8c6d354650fcb339f0520&client=cbc79c14efcebee57402&signature=44e59feb505c1b9c4e5867d453d3ed345010acac",
-                        "2018-03-09T13:00:00Z",
-                        Source("engadget", "Engadget")
-                ),
-                Article(
-                        "Magic Leap gets \$461M more, Travis goes VC, and HQ Trivia scales up",
-                        "Hello and welcome back to Equity, TechCrunch’s venture capital-focused podcast where we unpack the numbers behind the headlines. This week we had a corking set of news to get through, so we rounded up the usual gang (Matthew Lynley, Katie Roof, and myself), a…",
-                        "http://techcrunch.com/2018/03/09/magic-leap-gets-461m-more-travis-goes-vc-and-hq-trivia-scales-up/",
-                        "https://tctechcrunch2011.files.wordpress.com/2017/03/tc-equity-podcast-ios.jpg",
-                        "2018-03-09T14:10:01Z",
-                        Source("techcrunch", "TechCrunch")
-                )
+  private fun expectedNews(): List<Article> {
+    return listOf(
+        Article(
+            "How to Get Android P's Screenshot Editing Tool on Any Android Phone",
+            "Last year, Apple brought advanced screenshot editing tools to the iPhone with iOS 11, and, this week, Google fired back with a similar Android feature called Markup. The only catch is that this new tool is limited to Android P, which launches later this year …",
+            "https://lifehacker.com/how-to-get-android-ps-screenshot-editing-tool-on-any-an-1823646122",
+            "https://i.kinja-img.com/gawker-media/image/upload/s--Y-5X_NcT--/c_fill,fl_progressive,g_center,h_450,q_80,w_800/nxmwbkwzoc1z1tmak7s4.jpg",
+            "2018-03-09T20:30:00Z",
+            Source(null, "Lifehacker.com")
+        ),
+        Article(
+            "Capital One's virtual credit cards could help you avoid fraud",
+            "Capital One is no stranger to trying new things -- especially when it comes to technology. Its Eno texting chatbot, for example, is a quick and conversational way for its customers to check their balances and perform simple tasks, like checking on recent tran…",
+            "https://www.engadget.com/2018/03/09/capital-one-virtual-credit-cards/",
+            "https://o.aolcdn.com/images/dims?thumbnail=1200%2C630&quality=80&image_uri=https%3A%2F%2Fo.aolcdn.com%2Fimages%2Fdims%3Fcrop%3D3861%252C2574%252C0%252C0%26quality%3D85%26format%3Djpg%26resize%3D1600%252C1067%26image_uri%3Dhttp%253A%252F%252Fo.aolcdn.com%252Fhss%252Fstorage%252Fmidas%252Fca9d74d8d57677d4f3291ae4347b26da%252F206197048%252Fcapital-one-financial-corp-signage-is-displayed-at-a-bank-branch-in-picture-id120933061%26client%3Da1acac3e1b3290917d92%26signature%3Db51d9958f8487452f6a8c6d354650fcb339f0520&client=cbc79c14efcebee57402&signature=44e59feb505c1b9c4e5867d453d3ed345010acac",
+            "2018-03-09T13:00:00Z",
+            Source("engadget", "Engadget")
+        ),
+        Article(
+            "Magic Leap gets \$461M more, Travis goes VC, and HQ Trivia scales up",
+            "Hello and welcome back to Equity, TechCrunch’s venture capital-focused podcast where we unpack the numbers behind the headlines. This week we had a corking set of news to get through, so we rounded up the usual gang (Matthew Lynley, Katie Roof, and myself), a…",
+            "http://techcrunch.com/2018/03/09/magic-leap-gets-461m-more-travis-goes-vc-and-hq-trivia-scales-up/",
+            "https://tctechcrunch2011.files.wordpress.com/2017/03/tc-equity-podcast-ios.jpg",
+            "2018-03-09T14:10:01Z",
+            Source("techcrunch", "TechCrunch")
         )
-    }
+    )
+  }
 }

--- a/app/src/test/java/me/jorgecastillo/hiroaki/JacksonNewsNetworkDataSourceTest.kt
+++ b/app/src/test/java/me/jorgecastillo/hiroaki/JacksonNewsNetworkDataSourceTest.kt
@@ -1,6 +1,6 @@
 package me.jorgecastillo.hiroaki
 
-import kotlinx.coroutines.experimental.runBlocking
+import kotlinx.coroutines.runBlocking
 import me.jorgecastillo.hiroaki.Method.GET
 import me.jorgecastillo.hiroaki.Method.POST
 import me.jorgecastillo.hiroaki.data.datasource.JacksonNewsNetworkDataSource
@@ -23,114 +23,114 @@ import java.io.IOException
 @RunWith(MockitoJUnitRunner::class)
 class JacksonNewsNetworkDataSourceTest : MockServerSuite() {
 
-    private lateinit var dataSource: JacksonNewsNetworkDataSource
+  private lateinit var dataSource: JacksonNewsNetworkDataSource
 
-    @Before
-    override fun setup() {
-        super.setup()
-        dataSource = JacksonNewsNetworkDataSource(
-                server.retrofitService(
-                        JacksonNewsApiService::class.java,
-                        JacksonConverterFactory.create()
-                )
+  @Before
+  override fun setup() {
+    super.setup()
+    dataSource = JacksonNewsNetworkDataSource(
+        server.retrofitService(
+            JacksonNewsApiService::class.java,
+            JacksonConverterFactory.create()
         )
-    }
+    )
+  }
 
-    @Test
-    fun sendsGetNews() {
-        server.whenever(GET, "v2/top-headlines")
-                .thenRespond(success(jsonBody = fileBody("GetNews.json")))
+  @Test
+  fun sendsGetNews() {
+    server.whenever(GET, "v2/top-headlines")
+        .thenRespond(success(jsonBody = fileBody("GetNews.json")))
 
-        runBlocking { dataSource.getNews() }
+    runBlocking { dataSource.getNews() }
 
-        server.verify("v2/top-headlines").called(
-                times = once(),
-                queryParams = params(
-                        "sources" to "crypto-coins-news",
-                        "apiKey" to "a7c816f57c004c49a21bd458e11e2807"),
-                headers = headers(
-                        "Cache-Control" to "max-age=640000"
-                ),
-                method = GET)
-    }
+    server.verify("v2/top-headlines").called(
+        times = once(),
+        queryParams = params(
+            "sources" to "crypto-coins-news",
+            "apiKey" to "a7c816f57c004c49a21bd458e11e2807"),
+        headers = headers(
+            "Cache-Control" to "max-age=640000"
+        ),
+        method = GET)
+  }
 
-    @Test
-    fun sendsPublishHeadline() {
-        server.whenever(POST, "v2/top-headlines").thenRespond(success())
-        val article = anyArticle()
+  @Test
+  fun sendsPublishHeadline() {
+    server.whenever(POST, "v2/top-headlines").thenRespond(success())
+    val article = anyArticle()
 
-        runBlocking { dataSource.publishHeadline(article) }
+    runBlocking { dataSource.publishHeadline(article) }
 
-        server.verify("v2/top-headlines").called(
-                jsonBody = fileBody("PublishHeadline.json"),
-                method = POST)
-    }
+    server.verify("v2/top-headlines").called(
+        jsonBody = fileBody("PublishHeadline.json"),
+        method = POST)
+  }
 
-    @Test
-    fun sendsPublishHeadlineUsingInlineBody() {
-        server.whenever(POST, "v2/top-headlines").thenRespond(success())
-        val article = anyArticle()
+  @Test
+  fun sendsPublishHeadlineUsingInlineBody() {
+    server.whenever(POST, "v2/top-headlines").thenRespond(success())
+    val article = anyArticle()
 
-        runBlocking { dataSource.publishHeadline(article) }
+    runBlocking { dataSource.publishHeadline(article) }
 
-        server.verify("v2/top-headlines").called(
-                times = once(),
-                jsonBody = inlineBody("{\n" +
-                        "  \"title\": \"Any Title\",\n" +
-                        "  \"description\": \"Any description\",\n" +
-                        "  \"url\": \"http://any.url\",\n" +
-                        "  \"urlToImage\": \"http://any.url/any_image.png\",\n" +
-                        "  \"publishedAt\": \"2018-03-10T14:09:00Z\",\n" +
-                        "  \"source\": {\n" +
-                        "    \"id\": \"AnyId\",\n" +
-                        "    \"name\": \"ANYID\"\n" +
-                        "  }\n" +
-                        "}\n"))
-    }
+    server.verify("v2/top-headlines").called(
+        times = once(),
+        jsonBody = inlineBody("{\n" +
+            "  \"title\": \"Any Title\",\n" +
+            "  \"description\": \"Any description\",\n" +
+            "  \"url\": \"http://any.url\",\n" +
+            "  \"urlToImage\": \"http://any.url/any_image.png\",\n" +
+            "  \"publishedAt\": \"2018-03-10T14:09:00Z\",\n" +
+            "  \"source\": {\n" +
+            "    \"id\": \"AnyId\",\n" +
+            "    \"name\": \"ANYID\"\n" +
+            "  }\n" +
+            "}\n"))
+  }
 
-    @Test
-    fun parsesNewsProperly() {
-        server.whenever(GET, "v2/top-headlines")
-                .thenRespond(success(jsonBody = fileBody("GetNews.json")))
+  @Test
+  fun parsesNewsProperly() {
+    server.whenever(GET, "v2/top-headlines")
+        .thenRespond(success(jsonBody = fileBody("GetNews.json")))
 
-        val news = runBlocking { dataSource.getNews() }
+    val news = runBlocking { dataSource.getNews() }
 
-        news eq expectedNews()
-    }
+    news eq expectedNews()
+  }
 
-    @Test(expected = IOException::class)
-    fun throwsIOExceptionOnGetNewsErrorResponse() {
-        server.whenever(GET, "v2/top-headlines").thenRespond(error())
+  @Test(expected = IOException::class)
+  fun throwsIOExceptionOnGetNewsErrorResponse() {
+    server.whenever(GET, "v2/top-headlines").thenRespond(error())
 
-        runBlocking { dataSource.getNews() }
-    }
+    runBlocking { dataSource.getNews() }
+  }
 
-    private fun expectedNews(): List<Article> {
-        return listOf(
-                Article(
-                        "How to Get Android P's Screenshot Editing Tool on Any Android Phone",
-                        "Last year, Apple brought advanced screenshot editing tools to the iPhone with iOS 11, and, this week, Google fired back with a similar Android feature called Markup. The only catch is that this new tool is limited to Android P, which launches later this year …",
-                        "https://lifehacker.com/how-to-get-android-ps-screenshot-editing-tool-on-any-an-1823646122",
-                        "https://i.kinja-img.com/gawker-media/image/upload/s--Y-5X_NcT--/c_fill,fl_progressive,g_center,h_450,q_80,w_800/nxmwbkwzoc1z1tmak7s4.jpg",
-                        "2018-03-09T20:30:00Z",
-                        Source(null, "Lifehacker.com")
-                ),
-                Article(
-                        "Capital One's virtual credit cards could help you avoid fraud",
-                        "Capital One is no stranger to trying new things -- especially when it comes to technology. Its Eno texting chatbot, for example, is a quick and conversational way for its customers to check their balances and perform simple tasks, like checking on recent tran…",
-                        "https://www.engadget.com/2018/03/09/capital-one-virtual-credit-cards/",
-                        "https://o.aolcdn.com/images/dims?thumbnail=1200%2C630&quality=80&image_uri=https%3A%2F%2Fo.aolcdn.com%2Fimages%2Fdims%3Fcrop%3D3861%252C2574%252C0%252C0%26quality%3D85%26format%3Djpg%26resize%3D1600%252C1067%26image_uri%3Dhttp%253A%252F%252Fo.aolcdn.com%252Fhss%252Fstorage%252Fmidas%252Fca9d74d8d57677d4f3291ae4347b26da%252F206197048%252Fcapital-one-financial-corp-signage-is-displayed-at-a-bank-branch-in-picture-id120933061%26client%3Da1acac3e1b3290917d92%26signature%3Db51d9958f8487452f6a8c6d354650fcb339f0520&client=cbc79c14efcebee57402&signature=44e59feb505c1b9c4e5867d453d3ed345010acac",
-                        "2018-03-09T13:00:00Z",
-                        Source("engadget", "Engadget")
-                ),
-                Article(
-                        "Magic Leap gets \$461M more, Travis goes VC, and HQ Trivia scales up",
-                        "Hello and welcome back to Equity, TechCrunch’s venture capital-focused podcast where we unpack the numbers behind the headlines. This week we had a corking set of news to get through, so we rounded up the usual gang (Matthew Lynley, Katie Roof, and myself), a…",
-                        "http://techcrunch.com/2018/03/09/magic-leap-gets-461m-more-travis-goes-vc-and-hq-trivia-scales-up/",
-                        "https://tctechcrunch2011.files.wordpress.com/2017/03/tc-equity-podcast-ios.jpg",
-                        "2018-03-09T14:10:01Z",
-                        Source("techcrunch", "TechCrunch")
-                )
+  private fun expectedNews(): List<Article> {
+    return listOf(
+        Article(
+            "How to Get Android P's Screenshot Editing Tool on Any Android Phone",
+            "Last year, Apple brought advanced screenshot editing tools to the iPhone with iOS 11, and, this week, Google fired back with a similar Android feature called Markup. The only catch is that this new tool is limited to Android P, which launches later this year …",
+            "https://lifehacker.com/how-to-get-android-ps-screenshot-editing-tool-on-any-an-1823646122",
+            "https://i.kinja-img.com/gawker-media/image/upload/s--Y-5X_NcT--/c_fill,fl_progressive,g_center,h_450,q_80,w_800/nxmwbkwzoc1z1tmak7s4.jpg",
+            "2018-03-09T20:30:00Z",
+            Source(null, "Lifehacker.com")
+        ),
+        Article(
+            "Capital One's virtual credit cards could help you avoid fraud",
+            "Capital One is no stranger to trying new things -- especially when it comes to technology. Its Eno texting chatbot, for example, is a quick and conversational way for its customers to check their balances and perform simple tasks, like checking on recent tran…",
+            "https://www.engadget.com/2018/03/09/capital-one-virtual-credit-cards/",
+            "https://o.aolcdn.com/images/dims?thumbnail=1200%2C630&quality=80&image_uri=https%3A%2F%2Fo.aolcdn.com%2Fimages%2Fdims%3Fcrop%3D3861%252C2574%252C0%252C0%26quality%3D85%26format%3Djpg%26resize%3D1600%252C1067%26image_uri%3Dhttp%253A%252F%252Fo.aolcdn.com%252Fhss%252Fstorage%252Fmidas%252Fca9d74d8d57677d4f3291ae4347b26da%252F206197048%252Fcapital-one-financial-corp-signage-is-displayed-at-a-bank-branch-in-picture-id120933061%26client%3Da1acac3e1b3290917d92%26signature%3Db51d9958f8487452f6a8c6d354650fcb339f0520&client=cbc79c14efcebee57402&signature=44e59feb505c1b9c4e5867d453d3ed345010acac",
+            "2018-03-09T13:00:00Z",
+            Source("engadget", "Engadget")
+        ),
+        Article(
+            "Magic Leap gets \$461M more, Travis goes VC, and HQ Trivia scales up",
+            "Hello and welcome back to Equity, TechCrunch’s venture capital-focused podcast where we unpack the numbers behind the headlines. This week we had a corking set of news to get through, so we rounded up the usual gang (Matthew Lynley, Katie Roof, and myself), a…",
+            "http://techcrunch.com/2018/03/09/magic-leap-gets-461m-more-travis-goes-vc-and-hq-trivia-scales-up/",
+            "https://tctechcrunch2011.files.wordpress.com/2017/03/tc-equity-podcast-ios.jpg",
+            "2018-03-09T14:10:01Z",
+            Source("techcrunch", "TechCrunch")
         )
-    }
+    )
+  }
 }

--- a/app/src/test/java/me/jorgecastillo/hiroaki/JacksonNewsNetworkDataSourceTest.kt
+++ b/app/src/test/java/me/jorgecastillo/hiroaki/JacksonNewsNetworkDataSourceTest.kt
@@ -23,114 +23,114 @@ import java.io.IOException
 @RunWith(MockitoJUnitRunner::class)
 class JacksonNewsNetworkDataSourceTest : MockServerSuite() {
 
-  private lateinit var dataSource: JacksonNewsNetworkDataSource
+    private lateinit var dataSource: JacksonNewsNetworkDataSource
 
-  @Before
-  override fun setup() {
-    super.setup()
-    dataSource = JacksonNewsNetworkDataSource(
-        server.retrofitService(
-            JacksonNewsApiService::class.java,
-            JacksonConverterFactory.create()
+    @Before
+    override fun setup() {
+        super.setup()
+        dataSource = JacksonNewsNetworkDataSource(
+            server.retrofitService(
+                JacksonNewsApiService::class.java,
+                JacksonConverterFactory.create()
+            )
         )
-    )
-  }
+    }
 
-  @Test
-  fun sendsGetNews() {
-    server.whenever(GET, "v2/top-headlines")
-        .thenRespond(success(jsonBody = fileBody("GetNews.json")))
+    @Test
+    fun sendsGetNews() {
+        server.whenever(GET, "v2/top-headlines")
+            .thenRespond(success(jsonBody = fileBody("GetNews.json")))
 
-    runBlocking { dataSource.getNews() }
+        runBlocking { dataSource.getNews() }
 
-    server.verify("v2/top-headlines").called(
-        times = once(),
-        queryParams = params(
-            "sources" to "crypto-coins-news",
-            "apiKey" to "a7c816f57c004c49a21bd458e11e2807"),
-        headers = headers(
-            "Cache-Control" to "max-age=640000"
-        ),
-        method = GET)
-  }
+        server.verify("v2/top-headlines").called(
+            times = once(),
+            queryParams = params(
+                "sources" to "crypto-coins-news",
+                "apiKey" to "a7c816f57c004c49a21bd458e11e2807"),
+            headers = headers(
+                "Cache-Control" to "max-age=640000"
+            ),
+            method = GET)
+    }
 
-  @Test
-  fun sendsPublishHeadline() {
-    server.whenever(POST, "v2/top-headlines").thenRespond(success())
-    val article = anyArticle()
+    @Test
+    fun sendsPublishHeadline() {
+        server.whenever(POST, "v2/top-headlines").thenRespond(success())
+        val article = anyArticle()
 
-    runBlocking { dataSource.publishHeadline(article) }
+        runBlocking { dataSource.publishHeadline(article) }
 
-    server.verify("v2/top-headlines").called(
-        jsonBody = fileBody("PublishHeadline.json"),
-        method = POST)
-  }
+        server.verify("v2/top-headlines").called(
+            jsonBody = fileBody("PublishHeadline.json"),
+            method = POST)
+    }
 
-  @Test
-  fun sendsPublishHeadlineUsingInlineBody() {
-    server.whenever(POST, "v2/top-headlines").thenRespond(success())
-    val article = anyArticle()
+    @Test
+    fun sendsPublishHeadlineUsingInlineBody() {
+        server.whenever(POST, "v2/top-headlines").thenRespond(success())
+        val article = anyArticle()
 
-    runBlocking { dataSource.publishHeadline(article) }
+        runBlocking { dataSource.publishHeadline(article) }
 
-    server.verify("v2/top-headlines").called(
-        times = once(),
-        jsonBody = inlineBody("{\n" +
-            "  \"title\": \"Any Title\",\n" +
-            "  \"description\": \"Any description\",\n" +
-            "  \"url\": \"http://any.url\",\n" +
-            "  \"urlToImage\": \"http://any.url/any_image.png\",\n" +
-            "  \"publishedAt\": \"2018-03-10T14:09:00Z\",\n" +
-            "  \"source\": {\n" +
-            "    \"id\": \"AnyId\",\n" +
-            "    \"name\": \"ANYID\"\n" +
-            "  }\n" +
-            "}\n"))
-  }
+        server.verify("v2/top-headlines").called(
+            times = once(),
+            jsonBody = inlineBody("{\n" +
+                "  \"title\": \"Any Title\",\n" +
+                "  \"description\": \"Any description\",\n" +
+                "  \"url\": \"http://any.url\",\n" +
+                "  \"urlToImage\": \"http://any.url/any_image.png\",\n" +
+                "  \"publishedAt\": \"2018-03-10T14:09:00Z\",\n" +
+                "  \"source\": {\n" +
+                "    \"id\": \"AnyId\",\n" +
+                "    \"name\": \"ANYID\"\n" +
+                "  }\n" +
+                "}\n"))
+    }
 
-  @Test
-  fun parsesNewsProperly() {
-    server.whenever(GET, "v2/top-headlines")
-        .thenRespond(success(jsonBody = fileBody("GetNews.json")))
+    @Test
+    fun parsesNewsProperly() {
+        server.whenever(GET, "v2/top-headlines")
+            .thenRespond(success(jsonBody = fileBody("GetNews.json")))
 
-    val news = runBlocking { dataSource.getNews() }
+        val news = runBlocking { dataSource.getNews() }
 
-    news eq expectedNews()
-  }
+        news eq expectedNews()
+    }
 
-  @Test(expected = IOException::class)
-  fun throwsIOExceptionOnGetNewsErrorResponse() {
-    server.whenever(GET, "v2/top-headlines").thenRespond(error())
+    @Test(expected = IOException::class)
+    fun throwsIOExceptionOnGetNewsErrorResponse() {
+        server.whenever(GET, "v2/top-headlines").thenRespond(error())
 
-    runBlocking { dataSource.getNews() }
-  }
+        runBlocking { dataSource.getNews() }
+    }
 
-  private fun expectedNews(): List<Article> {
-    return listOf(
-        Article(
-            "How to Get Android P's Screenshot Editing Tool on Any Android Phone",
-            "Last year, Apple brought advanced screenshot editing tools to the iPhone with iOS 11, and, this week, Google fired back with a similar Android feature called Markup. The only catch is that this new tool is limited to Android P, which launches later this year …",
-            "https://lifehacker.com/how-to-get-android-ps-screenshot-editing-tool-on-any-an-1823646122",
-            "https://i.kinja-img.com/gawker-media/image/upload/s--Y-5X_NcT--/c_fill,fl_progressive,g_center,h_450,q_80,w_800/nxmwbkwzoc1z1tmak7s4.jpg",
-            "2018-03-09T20:30:00Z",
-            Source(null, "Lifehacker.com")
-        ),
-        Article(
-            "Capital One's virtual credit cards could help you avoid fraud",
-            "Capital One is no stranger to trying new things -- especially when it comes to technology. Its Eno texting chatbot, for example, is a quick and conversational way for its customers to check their balances and perform simple tasks, like checking on recent tran…",
-            "https://www.engadget.com/2018/03/09/capital-one-virtual-credit-cards/",
-            "https://o.aolcdn.com/images/dims?thumbnail=1200%2C630&quality=80&image_uri=https%3A%2F%2Fo.aolcdn.com%2Fimages%2Fdims%3Fcrop%3D3861%252C2574%252C0%252C0%26quality%3D85%26format%3Djpg%26resize%3D1600%252C1067%26image_uri%3Dhttp%253A%252F%252Fo.aolcdn.com%252Fhss%252Fstorage%252Fmidas%252Fca9d74d8d57677d4f3291ae4347b26da%252F206197048%252Fcapital-one-financial-corp-signage-is-displayed-at-a-bank-branch-in-picture-id120933061%26client%3Da1acac3e1b3290917d92%26signature%3Db51d9958f8487452f6a8c6d354650fcb339f0520&client=cbc79c14efcebee57402&signature=44e59feb505c1b9c4e5867d453d3ed345010acac",
-            "2018-03-09T13:00:00Z",
-            Source("engadget", "Engadget")
-        ),
-        Article(
-            "Magic Leap gets \$461M more, Travis goes VC, and HQ Trivia scales up",
-            "Hello and welcome back to Equity, TechCrunch’s venture capital-focused podcast where we unpack the numbers behind the headlines. This week we had a corking set of news to get through, so we rounded up the usual gang (Matthew Lynley, Katie Roof, and myself), a…",
-            "http://techcrunch.com/2018/03/09/magic-leap-gets-461m-more-travis-goes-vc-and-hq-trivia-scales-up/",
-            "https://tctechcrunch2011.files.wordpress.com/2017/03/tc-equity-podcast-ios.jpg",
-            "2018-03-09T14:10:01Z",
-            Source("techcrunch", "TechCrunch")
+    private fun expectedNews(): List<Article> {
+        return listOf(
+            Article(
+                "How to Get Android P's Screenshot Editing Tool on Any Android Phone",
+                "Last year, Apple brought advanced screenshot editing tools to the iPhone with iOS 11, and, this week, Google fired back with a similar Android feature called Markup. The only catch is that this new tool is limited to Android P, which launches later this year …",
+                "https://lifehacker.com/how-to-get-android-ps-screenshot-editing-tool-on-any-an-1823646122",
+                "https://i.kinja-img.com/gawker-media/image/upload/s--Y-5X_NcT--/c_fill,fl_progressive,g_center,h_450,q_80,w_800/nxmwbkwzoc1z1tmak7s4.jpg",
+                "2018-03-09T20:30:00Z",
+                Source(null, "Lifehacker.com")
+            ),
+            Article(
+                "Capital One's virtual credit cards could help you avoid fraud",
+                "Capital One is no stranger to trying new things -- especially when it comes to technology. Its Eno texting chatbot, for example, is a quick and conversational way for its customers to check their balances and perform simple tasks, like checking on recent tran…",
+                "https://www.engadget.com/2018/03/09/capital-one-virtual-credit-cards/",
+                "https://o.aolcdn.com/images/dims?thumbnail=1200%2C630&quality=80&image_uri=https%3A%2F%2Fo.aolcdn.com%2Fimages%2Fdims%3Fcrop%3D3861%252C2574%252C0%252C0%26quality%3D85%26format%3Djpg%26resize%3D1600%252C1067%26image_uri%3Dhttp%253A%252F%252Fo.aolcdn.com%252Fhss%252Fstorage%252Fmidas%252Fca9d74d8d57677d4f3291ae4347b26da%252F206197048%252Fcapital-one-financial-corp-signage-is-displayed-at-a-bank-branch-in-picture-id120933061%26client%3Da1acac3e1b3290917d92%26signature%3Db51d9958f8487452f6a8c6d354650fcb339f0520&client=cbc79c14efcebee57402&signature=44e59feb505c1b9c4e5867d453d3ed345010acac",
+                "2018-03-09T13:00:00Z",
+                Source("engadget", "Engadget")
+            ),
+            Article(
+                "Magic Leap gets \$461M more, Travis goes VC, and HQ Trivia scales up",
+                "Hello and welcome back to Equity, TechCrunch’s venture capital-focused podcast where we unpack the numbers behind the headlines. This week we had a corking set of news to get through, so we rounded up the usual gang (Matthew Lynley, Katie Roof, and myself), a…",
+                "http://techcrunch.com/2018/03/09/magic-leap-gets-461m-more-travis-goes-vc-and-hq-trivia-scales-up/",
+                "https://tctechcrunch2011.files.wordpress.com/2017/03/tc-equity-podcast-ios.jpg",
+                "2018-03-09T14:10:01Z",
+                Source("techcrunch", "TechCrunch")
+            )
         )
-    )
-  }
+    }
 }

--- a/app/src/test/java/me/jorgecastillo/hiroaki/MockingRequestsTest.kt
+++ b/app/src/test/java/me/jorgecastillo/hiroaki/MockingRequestsTest.kt
@@ -1,21 +1,13 @@
 package me.jorgecastillo.hiroaki
 
-import kotlinx.coroutines.experimental.runBlocking
+import kotlinx.coroutines.runBlocking
 import me.jorgecastillo.hiroaki.data.datasource.GsonNewsNetworkDataSource
 import me.jorgecastillo.hiroaki.data.service.GsonNewsApiService
 import me.jorgecastillo.hiroaki.internal.MockServerSuite
-import me.jorgecastillo.hiroaki.matchers.atLeast
-import me.jorgecastillo.hiroaki.matchers.atMost
-import me.jorgecastillo.hiroaki.matchers.never
-import me.jorgecastillo.hiroaki.matchers.order
-import me.jorgecastillo.hiroaki.matchers.times
+import me.jorgecastillo.hiroaki.matchers.*
 import me.jorgecastillo.hiroaki.model.Article
 import me.jorgecastillo.hiroaki.model.Source
-import me.jorgecastillo.hiroaki.models.error
-import me.jorgecastillo.hiroaki.models.fileBody
-import me.jorgecastillo.hiroaki.models.inlineBody
-import me.jorgecastillo.hiroaki.models.response
-import me.jorgecastillo.hiroaki.models.success
+import me.jorgecastillo.hiroaki.models.*
 import org.junit.Before
 import org.junit.Test
 import org.junit.runner.RunWith
@@ -26,313 +18,313 @@ import java.io.IOException
 @RunWith(MockitoJUnitRunner::class)
 class MockingRequestsTest : MockServerSuite() {
 
-    private lateinit var dataSource: GsonNewsNetworkDataSource
+  private lateinit var dataSource: GsonNewsNetworkDataSource
 
-    @Before
-    override fun setup() {
-        super.setup()
-        dataSource = GsonNewsNetworkDataSource(
-                server.retrofitService(
-                        GsonNewsApiService::class.java,
-                        GsonConverterFactory.create()
-                )
+  @Before
+  override fun setup() {
+    super.setup()
+    dataSource = GsonNewsNetworkDataSource(
+        server.retrofitService(
+            GsonNewsApiService::class.java,
+            GsonConverterFactory.create()
         )
-    }
-
-    @Test
-    fun enqueuesSuccess() {
-        server.enqueue(success(jsonBody = fileBody("GetNews.json")))
-
-        val news = runBlocking { dataSource.getNews() }
-
-        news eq expectedNews()
-    }
-
-    @Test(expected = IOException::class)
-    fun enqueueError() {
-        server.enqueue(error())
-
-        runBlocking { dataSource.getNews() }
-    }
-
-    @Test
-    fun enqueueMockResponseSuccess() {
-        server.enqueue(response(200, jsonBody = fileBody("GetNews.json")))
-
-        val news = runBlocking { dataSource.getNews() }
-
-        news eq expectedNews()
-    }
-
-    @Test(expected = IOException::class)
-    fun enqueueMockResponseError() {
-        server.enqueue(response(307))
-
-        runBlocking { dataSource.getNews() }
-    }
-
-    @Test
-    fun chainResponses() {
-        server.whenever(Method.GET, "v2/top-headlines")
-                .thenRespond(success(jsonBody = fileBody("GetNews.json")))
-                .thenRespond(success(jsonBody = fileBody("GetSingleNew.json")))
-                .thenRespond(success(jsonBody = fileBody("GetNews.json")))
-
-        val news = runBlocking { dataSource.getNews() }
-
-        news eq expectedNews()
-
-        val singleNew = runBlocking { dataSource.getNews() }
-
-        singleNew eq expectedSingleNew()
-
-        val news2 = runBlocking { dataSource.getNews() }
-
-        news2 eq expectedNews()
-    }
-
-    @Test
-    fun dispatchesCorrectly() {
-        server.whenever(Method.GET, "v2/top-headlines")
-                .thenDispatch { request ->
-                    success(jsonBody = inlineBody("{\n" +
-                            "  \"status\": \"ok\",\n" +
-                            "  \"totalResults\": 2342,\n" +
-                            "  \"articles\": [\n" +
-                            "    {\n" +
-                            "      \"source\": {\n" +
-                            "        \"id\": ${request.path.length},\n" +
-                            "        \"name\": \"Lifehacker.com\"\n" +
-                            "      },\n" +
-                            "      \"author\": \"Jacob Kleinman\",\n" +
-                            "      \"title\": \"How to Get Android P's Screenshot Editing Tool on Any Android Phone\",\n" +
-                            "      \"description\": \"Last year, Apple brought advanced screenshot editing tools to the iPhone with iOS 11, and, this week, Google fired back with a similar Android feature called Markup. The only catch is that this new tool is limited to Android P, which launches later this year …\",\n" +
-                            "      \"url\": \"https://lifehacker.com/how-to-get-android-ps-screenshot-editing-tool-on-any-an-1823646122\",\n" +
-                            "      \"urlToImage\": \"https://i.kinja-img.com/gawker-media/image/upload/s--Y-5X_NcT--/c_fill,fl_progressive,g_center,h_450,q_80,w_800/nxmwbkwzoc1z1tmak7s4.jpg\",\n" +
-                            "      \"publishedAt\": \"2018-03-09T20:30:00Z\"\n" +
-                            "    }\n" +
-                            "  ]\n" +
-                            "}"))
-                }
-
-        val singleNew = runBlocking { dataSource.getNews() }
-
-        singleNew eq expectedSingleNew(83)
-    }
-
-    @Test
-    fun matchesWithQueryParams() {
-        server.whenever(
-                method = Method.GET,
-                sentToPath = "v2/top-headlines",
-                queryParams = params("sources" to "crypto-coins-news",
-                        "apiKey" to "a7c816f57c004c49a21bd458e11e2807"))
-                .thenRespond(success(jsonBody = fileBody("GetNews.json")))
-
-        val news = runBlocking { dataSource.getNews() }
-
-        news eq expectedNews()
-    }
-
-    @Test(expected = IOException::class)
-    fun failsWithUnknownParams() {
-        server.whenever(Method.GET, "v2/top-headlines", params("randomParam" to "someValue"))
-                .thenRespond(success(jsonBody = fileBody("GetNews.json")))
-
-        runBlocking { dataSource.getNews() }
-    }
-
-    @Test
-    fun verifiesCall() {
-        server.whenever(Method.GET, "v2/top-headlines")
-                .thenRespond(success(jsonBody = fileBody("GetNews.json")))
-                .thenRespond(success(jsonBody = fileBody("GetNews.json")))
-                .thenRespond(success(jsonBody = fileBody("GetNews.json")))
-
-        runBlocking {
-            dataSource.getNews()
-            dataSource.getNews()
-            dataSource.getNews()
-        }
-
-        server.verify("v2/top-headlines").called(
-                times = times(3),
-                order = order(1, 2, 3),
-                method = Method.GET,
-                queryParams = params(
-                        "sources" to "crypto-coins-news",
-                        "apiKey" to "a7c816f57c004c49a21bd458e11e2807"),
-                headers = headers("Cache-Control" to "max-age=640000"))
-    }
-
-    @Test
-    fun verifiesAtLeast() {
-        server.whenever(Method.GET, "v2/top-headlines")
-                .thenRespond(success(jsonBody = fileBody("GetNews.json")))
-                .thenRespond(success(jsonBody = fileBody("GetNews.json")))
-                .thenRespond(success(jsonBody = fileBody("GetNews.json")))
-
-        runBlocking {
-            dataSource.getNews()
-            dataSource.getNews()
-            dataSource.getNews()
-        }
-
-        server.verify("v2/top-headlines").called(times = atLeast(3))
-    }
-
-    @Test
-    fun verifiesAtLeast2() {
-        server.whenever(Method.GET, "v2/top-headlines")
-                .thenRespond(success(jsonBody = fileBody("GetNews.json")))
-                .thenRespond(success(jsonBody = fileBody("GetNews.json")))
-                .thenRespond(success(jsonBody = fileBody("GetNews.json")))
-
-        runBlocking {
-            dataSource.getNews()
-            dataSource.getNews()
-            dataSource.getNews()
-        }
-
-        server.verify("v2/top-headlines").called(times = atLeast(1))
-    }
-
-    @Test(expected = AssertionError::class)
-    fun verifiesAtLeastError() {
-        server.whenever(Method.GET, "v2/top-headlines")
-                .thenRespond(success(jsonBody = fileBody("GetNews.json")))
-                .thenRespond(success(jsonBody = fileBody("GetNews.json")))
-                .thenRespond(success(jsonBody = fileBody("GetNews.json")))
-
-        runBlocking {
-            dataSource.getNews()
-            dataSource.getNews()
-            dataSource.getNews()
-        }
-
-        server.verify("v2/top-headlines").called(times = atLeast(4))
-    }
-
-    @Test
-    fun verifiesAtMost() {
-        server.whenever(Method.GET, "v2/top-headlines")
-                .thenRespond(success(jsonBody = fileBody("GetNews.json")))
-                .thenRespond(success(jsonBody = fileBody("GetNews.json")))
-                .thenRespond(success(jsonBody = fileBody("GetNews.json")))
-
-        runBlocking {
-            dataSource.getNews()
-            dataSource.getNews()
-            dataSource.getNews()
-        }
-
-        server.verify("v2/top-headlines").called(times = atMost(3))
-    }
-
-    @Test
-    fun verifiesAtMost2() {
-        server.whenever(Method.GET, "v2/top-headlines")
-                .thenRespond(success(jsonBody = fileBody("GetNews.json")))
-                .thenRespond(success(jsonBody = fileBody("GetNews.json")))
-                .thenRespond(success(jsonBody = fileBody("GetNews.json")))
-
-        runBlocking {
-            dataSource.getNews()
-            dataSource.getNews()
-            dataSource.getNews()
-        }
-
-        server.verify("v2/top-headlines").called(times = atMost(4))
-    }
-
-    @Test(expected = AssertionError::class)
-    fun verifiesAtMostError() {
-        server.whenever(Method.GET, "v2/top-headlines")
-                .thenRespond(success(jsonBody = fileBody("GetNews.json")))
-                .thenRespond(success(jsonBody = fileBody("GetNews.json")))
-                .thenRespond(success(jsonBody = fileBody("GetNews.json")))
-
-        runBlocking {
-            dataSource.getNews()
-            dataSource.getNews()
-            dataSource.getNews()
-        }
-
-        server.verify("v2/top-headlines").called(times = atMost(2))
-    }
-
-    @Test(expected = AssertionError::class)
-    fun verifiesNeverError() {
-        server.whenever(Method.GET, "v2/top-headlines")
-                .thenRespond(success(jsonBody = fileBody("GetNews.json")))
-                .thenRespond(success(jsonBody = fileBody("GetNews.json")))
-                .thenRespond(success(jsonBody = fileBody("GetNews.json")))
-
-        runBlocking {
-            dataSource.getNews()
-            dataSource.getNews()
-            dataSource.getNews()
-        }
-
-        server.verify("v2/top-headlines").called(times = never())
-    }
-
-    @Test
-    fun verifiesNever() {
-        server.whenever(Method.GET, "v2/top-headlines")
-                .thenRespond(success(jsonBody = fileBody("GetNews.json")))
-                .thenRespond(success(jsonBody = fileBody("GetNews.json")))
-                .thenRespond(success(jsonBody = fileBody("GetNews.json")))
-
-        runBlocking {
-            dataSource.getNews()
-            dataSource.getNews()
-            dataSource.getNews()
-        }
-
-        server.verify("v2/users").called(times = never())
-    }
-
-    private fun expectedNews(): List<Article> {
-        return listOf(
-                Article(
-                        "How to Get Android P's Screenshot Editing Tool on Any Android Phone",
-                        "Last year, Apple brought advanced screenshot editing tools to the iPhone with iOS 11, and, this week, Google fired back with a similar Android feature called Markup. The only catch is that this new tool is limited to Android P, which launches later this year …",
-                        "https://lifehacker.com/how-to-get-android-ps-screenshot-editing-tool-on-any-an-1823646122",
-                        "https://i.kinja-img.com/gawker-media/image/upload/s--Y-5X_NcT--/c_fill,fl_progressive,g_center,h_450,q_80,w_800/nxmwbkwzoc1z1tmak7s4.jpg",
-                        "2018-03-09T20:30:00Z",
-                        Source(null, "Lifehacker.com")
-                ),
-                Article(
-                        "Capital One's virtual credit cards could help you avoid fraud",
-                        "Capital One is no stranger to trying new things -- especially when it comes to technology. Its Eno texting chatbot, for example, is a quick and conversational way for its customers to check their balances and perform simple tasks, like checking on recent tran…",
-                        "https://www.engadget.com/2018/03/09/capital-one-virtual-credit-cards/",
-                        "https://o.aolcdn.com/images/dims?thumbnail=1200%2C630&quality=80&image_uri=https%3A%2F%2Fo.aolcdn.com%2Fimages%2Fdims%3Fcrop%3D3861%252C2574%252C0%252C0%26quality%3D85%26format%3Djpg%26resize%3D1600%252C1067%26image_uri%3Dhttp%253A%252F%252Fo.aolcdn.com%252Fhss%252Fstorage%252Fmidas%252Fca9d74d8d57677d4f3291ae4347b26da%252F206197048%252Fcapital-one-financial-corp-signage-is-displayed-at-a-bank-branch-in-picture-id120933061%26client%3Da1acac3e1b3290917d92%26signature%3Db51d9958f8487452f6a8c6d354650fcb339f0520&client=cbc79c14efcebee57402&signature=44e59feb505c1b9c4e5867d453d3ed345010acac",
-                        "2018-03-09T13:00:00Z",
-                        Source("engadget", "Engadget")
-                ),
-                Article(
-                        "Magic Leap gets \$461M more, Travis goes VC, and HQ Trivia scales up",
-                        "Hello and welcome back to Equity, TechCrunch’s venture capital-focused podcast where we unpack the numbers behind the headlines. This week we had a corking set of news to get through, so we rounded up the usual gang (Matthew Lynley, Katie Roof, and myself), a…",
-                        "http://techcrunch.com/2018/03/09/magic-leap-gets-461m-more-travis-goes-vc-and-hq-trivia-scales-up/",
-                        "https://tctechcrunch2011.files.wordpress.com/2017/03/tc-equity-podcast-ios.jpg",
-                        "2018-03-09T14:10:01Z",
-                        Source("techcrunch", "TechCrunch")
-                )
-        )
-    }
-
-    private fun expectedSingleNew(requestPathLengthAsSourceId: Int? = null): List<Article> = listOf(
-            Article(
-                    "How to Get Android P's Screenshot Editing Tool on Any Android Phone",
-                    "Last year, Apple brought advanced screenshot editing tools to the iPhone with iOS 11, and, this week, Google fired back with a similar Android feature called Markup. The only catch is that this new tool is limited to Android P, which launches later this year …",
-                    "https://lifehacker.com/how-to-get-android-ps-screenshot-editing-tool-on-any-an-1823646122",
-                    "https://i.kinja-img.com/gawker-media/image/upload/s--Y-5X_NcT--/c_fill,fl_progressive,g_center,h_450,q_80,w_800/nxmwbkwzoc1z1tmak7s4.jpg",
-                    "2018-03-09T20:30:00Z",
-                    Source(
-                            if (requestPathLengthAsSourceId != null) "$requestPathLengthAsSourceId" else null,
-                            "Lifehacker.com"
-                    )
-            )
     )
+  }
+
+  @Test
+  fun enqueuesSuccess() {
+    server.enqueue(success(jsonBody = fileBody("GetNews.json")))
+
+    val news = runBlocking { dataSource.getNews() }
+
+    news eq expectedNews()
+  }
+
+  @Test(expected = IOException::class)
+  fun enqueueError() {
+    server.enqueue(error())
+
+    runBlocking { dataSource.getNews() }
+  }
+
+  @Test
+  fun enqueueMockResponseSuccess() {
+    server.enqueue(response(200, jsonBody = fileBody("GetNews.json")))
+
+    val news = runBlocking { dataSource.getNews() }
+
+    news eq expectedNews()
+  }
+
+  @Test(expected = IOException::class)
+  fun enqueueMockResponseError() {
+    server.enqueue(response(307))
+
+    runBlocking { dataSource.getNews() }
+  }
+
+  @Test
+  fun chainResponses() {
+    server.whenever(Method.GET, "v2/top-headlines")
+        .thenRespond(success(jsonBody = fileBody("GetNews.json")))
+        .thenRespond(success(jsonBody = fileBody("GetSingleNew.json")))
+        .thenRespond(success(jsonBody = fileBody("GetNews.json")))
+
+    val news = runBlocking { dataSource.getNews() }
+
+    news eq expectedNews()
+
+    val singleNew = runBlocking { dataSource.getNews() }
+
+    singleNew eq expectedSingleNew()
+
+    val news2 = runBlocking { dataSource.getNews() }
+
+    news2 eq expectedNews()
+  }
+
+  @Test
+  fun dispatchesCorrectly() {
+    server.whenever(Method.GET, "v2/top-headlines")
+        .thenDispatch { request ->
+          success(jsonBody = inlineBody("{\n" +
+              "  \"status\": \"ok\",\n" +
+              "  \"totalResults\": 2342,\n" +
+              "  \"articles\": [\n" +
+              "    {\n" +
+              "      \"source\": {\n" +
+              "        \"id\": ${request.path.length},\n" +
+              "        \"name\": \"Lifehacker.com\"\n" +
+              "      },\n" +
+              "      \"author\": \"Jacob Kleinman\",\n" +
+              "      \"title\": \"How to Get Android P's Screenshot Editing Tool on Any Android Phone\",\n" +
+              "      \"description\": \"Last year, Apple brought advanced screenshot editing tools to the iPhone with iOS 11, and, this week, Google fired back with a similar Android feature called Markup. The only catch is that this new tool is limited to Android P, which launches later this year …\",\n" +
+              "      \"url\": \"https://lifehacker.com/how-to-get-android-ps-screenshot-editing-tool-on-any-an-1823646122\",\n" +
+              "      \"urlToImage\": \"https://i.kinja-img.com/gawker-media/image/upload/s--Y-5X_NcT--/c_fill,fl_progressive,g_center,h_450,q_80,w_800/nxmwbkwzoc1z1tmak7s4.jpg\",\n" +
+              "      \"publishedAt\": \"2018-03-09T20:30:00Z\"\n" +
+              "    }\n" +
+              "  ]\n" +
+              "}"))
+        }
+
+    val singleNew = runBlocking { dataSource.getNews() }
+
+    singleNew eq expectedSingleNew(83)
+  }
+
+  @Test
+  fun matchesWithQueryParams() {
+    server.whenever(
+        method = Method.GET,
+        sentToPath = "v2/top-headlines",
+        queryParams = params("sources" to "crypto-coins-news",
+            "apiKey" to "a7c816f57c004c49a21bd458e11e2807"))
+        .thenRespond(success(jsonBody = fileBody("GetNews.json")))
+
+    val news = runBlocking { dataSource.getNews() }
+
+    news eq expectedNews()
+  }
+
+  @Test(expected = IOException::class)
+  fun failsWithUnknownParams() {
+    server.whenever(Method.GET, "v2/top-headlines", params("randomParam" to "someValue"))
+        .thenRespond(success(jsonBody = fileBody("GetNews.json")))
+
+    runBlocking { dataSource.getNews() }
+  }
+
+  @Test
+  fun verifiesCall() {
+    server.whenever(Method.GET, "v2/top-headlines")
+        .thenRespond(success(jsonBody = fileBody("GetNews.json")))
+        .thenRespond(success(jsonBody = fileBody("GetNews.json")))
+        .thenRespond(success(jsonBody = fileBody("GetNews.json")))
+
+    runBlocking {
+      dataSource.getNews()
+      dataSource.getNews()
+      dataSource.getNews()
+    }
+
+    server.verify("v2/top-headlines").called(
+        times = times(3),
+        order = order(1, 2, 3),
+        method = Method.GET,
+        queryParams = params(
+            "sources" to "crypto-coins-news",
+            "apiKey" to "a7c816f57c004c49a21bd458e11e2807"),
+        headers = headers("Cache-Control" to "max-age=640000"))
+  }
+
+  @Test
+  fun verifiesAtLeast() {
+    server.whenever(Method.GET, "v2/top-headlines")
+        .thenRespond(success(jsonBody = fileBody("GetNews.json")))
+        .thenRespond(success(jsonBody = fileBody("GetNews.json")))
+        .thenRespond(success(jsonBody = fileBody("GetNews.json")))
+
+    runBlocking {
+      dataSource.getNews()
+      dataSource.getNews()
+      dataSource.getNews()
+    }
+
+    server.verify("v2/top-headlines").called(times = atLeast(3))
+  }
+
+  @Test
+  fun verifiesAtLeast2() {
+    server.whenever(Method.GET, "v2/top-headlines")
+        .thenRespond(success(jsonBody = fileBody("GetNews.json")))
+        .thenRespond(success(jsonBody = fileBody("GetNews.json")))
+        .thenRespond(success(jsonBody = fileBody("GetNews.json")))
+
+    runBlocking {
+      dataSource.getNews()
+      dataSource.getNews()
+      dataSource.getNews()
+    }
+
+    server.verify("v2/top-headlines").called(times = atLeast(1))
+  }
+
+  @Test(expected = AssertionError::class)
+  fun verifiesAtLeastError() {
+    server.whenever(Method.GET, "v2/top-headlines")
+        .thenRespond(success(jsonBody = fileBody("GetNews.json")))
+        .thenRespond(success(jsonBody = fileBody("GetNews.json")))
+        .thenRespond(success(jsonBody = fileBody("GetNews.json")))
+
+    runBlocking {
+      dataSource.getNews()
+      dataSource.getNews()
+      dataSource.getNews()
+    }
+
+    server.verify("v2/top-headlines").called(times = atLeast(4))
+  }
+
+  @Test
+  fun verifiesAtMost() {
+    server.whenever(Method.GET, "v2/top-headlines")
+        .thenRespond(success(jsonBody = fileBody("GetNews.json")))
+        .thenRespond(success(jsonBody = fileBody("GetNews.json")))
+        .thenRespond(success(jsonBody = fileBody("GetNews.json")))
+
+    runBlocking {
+      dataSource.getNews()
+      dataSource.getNews()
+      dataSource.getNews()
+    }
+
+    server.verify("v2/top-headlines").called(times = atMost(3))
+  }
+
+  @Test
+  fun verifiesAtMost2() {
+    server.whenever(Method.GET, "v2/top-headlines")
+        .thenRespond(success(jsonBody = fileBody("GetNews.json")))
+        .thenRespond(success(jsonBody = fileBody("GetNews.json")))
+        .thenRespond(success(jsonBody = fileBody("GetNews.json")))
+
+    runBlocking {
+      dataSource.getNews()
+      dataSource.getNews()
+      dataSource.getNews()
+    }
+
+    server.verify("v2/top-headlines").called(times = atMost(4))
+  }
+
+  @Test(expected = AssertionError::class)
+  fun verifiesAtMostError() {
+    server.whenever(Method.GET, "v2/top-headlines")
+        .thenRespond(success(jsonBody = fileBody("GetNews.json")))
+        .thenRespond(success(jsonBody = fileBody("GetNews.json")))
+        .thenRespond(success(jsonBody = fileBody("GetNews.json")))
+
+    runBlocking {
+      dataSource.getNews()
+      dataSource.getNews()
+      dataSource.getNews()
+    }
+
+    server.verify("v2/top-headlines").called(times = atMost(2))
+  }
+
+  @Test(expected = AssertionError::class)
+  fun verifiesNeverError() {
+    server.whenever(Method.GET, "v2/top-headlines")
+        .thenRespond(success(jsonBody = fileBody("GetNews.json")))
+        .thenRespond(success(jsonBody = fileBody("GetNews.json")))
+        .thenRespond(success(jsonBody = fileBody("GetNews.json")))
+
+    runBlocking {
+      dataSource.getNews()
+      dataSource.getNews()
+      dataSource.getNews()
+    }
+
+    server.verify("v2/top-headlines").called(times = never())
+  }
+
+  @Test
+  fun verifiesNever() {
+    server.whenever(Method.GET, "v2/top-headlines")
+        .thenRespond(success(jsonBody = fileBody("GetNews.json")))
+        .thenRespond(success(jsonBody = fileBody("GetNews.json")))
+        .thenRespond(success(jsonBody = fileBody("GetNews.json")))
+
+    runBlocking {
+      dataSource.getNews()
+      dataSource.getNews()
+      dataSource.getNews()
+    }
+
+    server.verify("v2/users").called(times = never())
+  }
+
+  private fun expectedNews(): List<Article> {
+    return listOf(
+        Article(
+            "How to Get Android P's Screenshot Editing Tool on Any Android Phone",
+            "Last year, Apple brought advanced screenshot editing tools to the iPhone with iOS 11, and, this week, Google fired back with a similar Android feature called Markup. The only catch is that this new tool is limited to Android P, which launches later this year …",
+            "https://lifehacker.com/how-to-get-android-ps-screenshot-editing-tool-on-any-an-1823646122",
+            "https://i.kinja-img.com/gawker-media/image/upload/s--Y-5X_NcT--/c_fill,fl_progressive,g_center,h_450,q_80,w_800/nxmwbkwzoc1z1tmak7s4.jpg",
+            "2018-03-09T20:30:00Z",
+            Source(null, "Lifehacker.com")
+        ),
+        Article(
+            "Capital One's virtual credit cards could help you avoid fraud",
+            "Capital One is no stranger to trying new things -- especially when it comes to technology. Its Eno texting chatbot, for example, is a quick and conversational way for its customers to check their balances and perform simple tasks, like checking on recent tran…",
+            "https://www.engadget.com/2018/03/09/capital-one-virtual-credit-cards/",
+            "https://o.aolcdn.com/images/dims?thumbnail=1200%2C630&quality=80&image_uri=https%3A%2F%2Fo.aolcdn.com%2Fimages%2Fdims%3Fcrop%3D3861%252C2574%252C0%252C0%26quality%3D85%26format%3Djpg%26resize%3D1600%252C1067%26image_uri%3Dhttp%253A%252F%252Fo.aolcdn.com%252Fhss%252Fstorage%252Fmidas%252Fca9d74d8d57677d4f3291ae4347b26da%252F206197048%252Fcapital-one-financial-corp-signage-is-displayed-at-a-bank-branch-in-picture-id120933061%26client%3Da1acac3e1b3290917d92%26signature%3Db51d9958f8487452f6a8c6d354650fcb339f0520&client=cbc79c14efcebee57402&signature=44e59feb505c1b9c4e5867d453d3ed345010acac",
+            "2018-03-09T13:00:00Z",
+            Source("engadget", "Engadget")
+        ),
+        Article(
+            "Magic Leap gets \$461M more, Travis goes VC, and HQ Trivia scales up",
+            "Hello and welcome back to Equity, TechCrunch’s venture capital-focused podcast where we unpack the numbers behind the headlines. This week we had a corking set of news to get through, so we rounded up the usual gang (Matthew Lynley, Katie Roof, and myself), a…",
+            "http://techcrunch.com/2018/03/09/magic-leap-gets-461m-more-travis-goes-vc-and-hq-trivia-scales-up/",
+            "https://tctechcrunch2011.files.wordpress.com/2017/03/tc-equity-podcast-ios.jpg",
+            "2018-03-09T14:10:01Z",
+            Source("techcrunch", "TechCrunch")
+        )
+    )
+  }
+
+  private fun expectedSingleNew(requestPathLengthAsSourceId: Int? = null): List<Article> = listOf(
+      Article(
+          "How to Get Android P's Screenshot Editing Tool on Any Android Phone",
+          "Last year, Apple brought advanced screenshot editing tools to the iPhone with iOS 11, and, this week, Google fired back with a similar Android feature called Markup. The only catch is that this new tool is limited to Android P, which launches later this year …",
+          "https://lifehacker.com/how-to-get-android-ps-screenshot-editing-tool-on-any-an-1823646122",
+          "https://i.kinja-img.com/gawker-media/image/upload/s--Y-5X_NcT--/c_fill,fl_progressive,g_center,h_450,q_80,w_800/nxmwbkwzoc1z1tmak7s4.jpg",
+          "2018-03-09T20:30:00Z",
+          Source(
+              if (requestPathLengthAsSourceId != null) "$requestPathLengthAsSourceId" else null,
+              "Lifehacker.com"
+          )
+      )
+  )
 }

--- a/app/src/test/java/me/jorgecastillo/hiroaki/MockingRequestsTest.kt
+++ b/app/src/test/java/me/jorgecastillo/hiroaki/MockingRequestsTest.kt
@@ -4,10 +4,18 @@ import kotlinx.coroutines.runBlocking
 import me.jorgecastillo.hiroaki.data.datasource.GsonNewsNetworkDataSource
 import me.jorgecastillo.hiroaki.data.service.GsonNewsApiService
 import me.jorgecastillo.hiroaki.internal.MockServerSuite
-import me.jorgecastillo.hiroaki.matchers.*
+import me.jorgecastillo.hiroaki.matchers.atLeast
+import me.jorgecastillo.hiroaki.matchers.atMost
+import me.jorgecastillo.hiroaki.matchers.never
+import me.jorgecastillo.hiroaki.matchers.order
+import me.jorgecastillo.hiroaki.matchers.times
 import me.jorgecastillo.hiroaki.model.Article
 import me.jorgecastillo.hiroaki.model.Source
-import me.jorgecastillo.hiroaki.models.*
+import me.jorgecastillo.hiroaki.models.error
+import me.jorgecastillo.hiroaki.models.fileBody
+import me.jorgecastillo.hiroaki.models.inlineBody
+import me.jorgecastillo.hiroaki.models.response
+import me.jorgecastillo.hiroaki.models.success
 import org.junit.Before
 import org.junit.Test
 import org.junit.runner.RunWith
@@ -18,313 +26,313 @@ import java.io.IOException
 @RunWith(MockitoJUnitRunner::class)
 class MockingRequestsTest : MockServerSuite() {
 
-  private lateinit var dataSource: GsonNewsNetworkDataSource
+    private lateinit var dataSource: GsonNewsNetworkDataSource
 
-  @Before
-  override fun setup() {
-    super.setup()
-    dataSource = GsonNewsNetworkDataSource(
-        server.retrofitService(
-            GsonNewsApiService::class.java,
-            GsonConverterFactory.create()
+    @Before
+    override fun setup() {
+        super.setup()
+        dataSource = GsonNewsNetworkDataSource(
+                server.retrofitService(
+                        GsonNewsApiService::class.java,
+                        GsonConverterFactory.create()
+                )
         )
-    )
-  }
+    }
 
-  @Test
-  fun enqueuesSuccess() {
-    server.enqueue(success(jsonBody = fileBody("GetNews.json")))
+    @Test
+    fun enqueuesSuccess() {
+        server.enqueue(success(jsonBody = fileBody("GetNews.json")))
 
-    val news = runBlocking { dataSource.getNews() }
+        val news = runBlocking { dataSource.getNews() }
 
-    news eq expectedNews()
-  }
+        news eq expectedNews()
+    }
 
-  @Test(expected = IOException::class)
-  fun enqueueError() {
-    server.enqueue(error())
+    @Test(expected = IOException::class)
+    fun enqueueError() {
+        server.enqueue(error())
 
-    runBlocking { dataSource.getNews() }
-  }
+        runBlocking { dataSource.getNews() }
+    }
 
-  @Test
-  fun enqueueMockResponseSuccess() {
-    server.enqueue(response(200, jsonBody = fileBody("GetNews.json")))
+    @Test
+    fun enqueueMockResponseSuccess() {
+        server.enqueue(response(200, jsonBody = fileBody("GetNews.json")))
 
-    val news = runBlocking { dataSource.getNews() }
+        val news = runBlocking { dataSource.getNews() }
 
-    news eq expectedNews()
-  }
+        news eq expectedNews()
+    }
 
-  @Test(expected = IOException::class)
-  fun enqueueMockResponseError() {
-    server.enqueue(response(307))
+    @Test(expected = IOException::class)
+    fun enqueueMockResponseError() {
+        server.enqueue(response(307))
 
-    runBlocking { dataSource.getNews() }
-  }
+        runBlocking { dataSource.getNews() }
+    }
 
-  @Test
-  fun chainResponses() {
-    server.whenever(Method.GET, "v2/top-headlines")
-        .thenRespond(success(jsonBody = fileBody("GetNews.json")))
-        .thenRespond(success(jsonBody = fileBody("GetSingleNew.json")))
-        .thenRespond(success(jsonBody = fileBody("GetNews.json")))
+    @Test
+    fun chainResponses() {
+        server.whenever(Method.GET, "v2/top-headlines")
+                .thenRespond(success(jsonBody = fileBody("GetNews.json")))
+                .thenRespond(success(jsonBody = fileBody("GetSingleNew.json")))
+                .thenRespond(success(jsonBody = fileBody("GetNews.json")))
 
-    val news = runBlocking { dataSource.getNews() }
+        val news = runBlocking { dataSource.getNews() }
 
-    news eq expectedNews()
+        news eq expectedNews()
 
-    val singleNew = runBlocking { dataSource.getNews() }
+        val singleNew = runBlocking { dataSource.getNews() }
 
-    singleNew eq expectedSingleNew()
+        singleNew eq expectedSingleNew()
 
-    val news2 = runBlocking { dataSource.getNews() }
+        val news2 = runBlocking { dataSource.getNews() }
 
-    news2 eq expectedNews()
-  }
+        news2 eq expectedNews()
+    }
 
-  @Test
-  fun dispatchesCorrectly() {
-    server.whenever(Method.GET, "v2/top-headlines")
-        .thenDispatch { request ->
-          success(jsonBody = inlineBody("{\n" +
-              "  \"status\": \"ok\",\n" +
-              "  \"totalResults\": 2342,\n" +
-              "  \"articles\": [\n" +
-              "    {\n" +
-              "      \"source\": {\n" +
-              "        \"id\": ${request.path.length},\n" +
-              "        \"name\": \"Lifehacker.com\"\n" +
-              "      },\n" +
-              "      \"author\": \"Jacob Kleinman\",\n" +
-              "      \"title\": \"How to Get Android P's Screenshot Editing Tool on Any Android Phone\",\n" +
-              "      \"description\": \"Last year, Apple brought advanced screenshot editing tools to the iPhone with iOS 11, and, this week, Google fired back with a similar Android feature called Markup. The only catch is that this new tool is limited to Android P, which launches later this year …\",\n" +
-              "      \"url\": \"https://lifehacker.com/how-to-get-android-ps-screenshot-editing-tool-on-any-an-1823646122\",\n" +
-              "      \"urlToImage\": \"https://i.kinja-img.com/gawker-media/image/upload/s--Y-5X_NcT--/c_fill,fl_progressive,g_center,h_450,q_80,w_800/nxmwbkwzoc1z1tmak7s4.jpg\",\n" +
-              "      \"publishedAt\": \"2018-03-09T20:30:00Z\"\n" +
-              "    }\n" +
-              "  ]\n" +
-              "}"))
+    @Test
+    fun dispatchesCorrectly() {
+        server.whenever(Method.GET, "v2/top-headlines")
+                .thenDispatch { request ->
+                    success(jsonBody = inlineBody("{\n" +
+                            "  \"status\": \"ok\",\n" +
+                            "  \"totalResults\": 2342,\n" +
+                            "  \"articles\": [\n" +
+                            "    {\n" +
+                            "      \"source\": {\n" +
+                            "        \"id\": ${request.path.length},\n" +
+                            "        \"name\": \"Lifehacker.com\"\n" +
+                            "      },\n" +
+                            "      \"author\": \"Jacob Kleinman\",\n" +
+                            "      \"title\": \"How to Get Android P's Screenshot Editing Tool on Any Android Phone\",\n" +
+                            "      \"description\": \"Last year, Apple brought advanced screenshot editing tools to the iPhone with iOS 11, and, this week, Google fired back with a similar Android feature called Markup. The only catch is that this new tool is limited to Android P, which launches later this year …\",\n" +
+                            "      \"url\": \"https://lifehacker.com/how-to-get-android-ps-screenshot-editing-tool-on-any-an-1823646122\",\n" +
+                            "      \"urlToImage\": \"https://i.kinja-img.com/gawker-media/image/upload/s--Y-5X_NcT--/c_fill,fl_progressive,g_center,h_450,q_80,w_800/nxmwbkwzoc1z1tmak7s4.jpg\",\n" +
+                            "      \"publishedAt\": \"2018-03-09T20:30:00Z\"\n" +
+                            "    }\n" +
+                            "  ]\n" +
+                            "}"))
+                }
+
+        val singleNew = runBlocking { dataSource.getNews() }
+
+        singleNew eq expectedSingleNew(83)
+    }
+
+    @Test
+    fun matchesWithQueryParams() {
+        server.whenever(
+                method = Method.GET,
+                sentToPath = "v2/top-headlines",
+                queryParams = params("sources" to "crypto-coins-news",
+                        "apiKey" to "a7c816f57c004c49a21bd458e11e2807"))
+                .thenRespond(success(jsonBody = fileBody("GetNews.json")))
+
+        val news = runBlocking { dataSource.getNews() }
+
+        news eq expectedNews()
+    }
+
+    @Test(expected = IOException::class)
+    fun failsWithUnknownParams() {
+        server.whenever(Method.GET, "v2/top-headlines", params("randomParam" to "someValue"))
+                .thenRespond(success(jsonBody = fileBody("GetNews.json")))
+
+        runBlocking { dataSource.getNews() }
+    }
+
+    @Test
+    fun verifiesCall() {
+        server.whenever(Method.GET, "v2/top-headlines")
+                .thenRespond(success(jsonBody = fileBody("GetNews.json")))
+                .thenRespond(success(jsonBody = fileBody("GetNews.json")))
+                .thenRespond(success(jsonBody = fileBody("GetNews.json")))
+
+        runBlocking {
+            dataSource.getNews()
+            dataSource.getNews()
+            dataSource.getNews()
         }
 
-    val singleNew = runBlocking { dataSource.getNews() }
-
-    singleNew eq expectedSingleNew(83)
-  }
-
-  @Test
-  fun matchesWithQueryParams() {
-    server.whenever(
-        method = Method.GET,
-        sentToPath = "v2/top-headlines",
-        queryParams = params("sources" to "crypto-coins-news",
-            "apiKey" to "a7c816f57c004c49a21bd458e11e2807"))
-        .thenRespond(success(jsonBody = fileBody("GetNews.json")))
-
-    val news = runBlocking { dataSource.getNews() }
-
-    news eq expectedNews()
-  }
-
-  @Test(expected = IOException::class)
-  fun failsWithUnknownParams() {
-    server.whenever(Method.GET, "v2/top-headlines", params("randomParam" to "someValue"))
-        .thenRespond(success(jsonBody = fileBody("GetNews.json")))
-
-    runBlocking { dataSource.getNews() }
-  }
-
-  @Test
-  fun verifiesCall() {
-    server.whenever(Method.GET, "v2/top-headlines")
-        .thenRespond(success(jsonBody = fileBody("GetNews.json")))
-        .thenRespond(success(jsonBody = fileBody("GetNews.json")))
-        .thenRespond(success(jsonBody = fileBody("GetNews.json")))
-
-    runBlocking {
-      dataSource.getNews()
-      dataSource.getNews()
-      dataSource.getNews()
+        server.verify("v2/top-headlines").called(
+                times = times(3),
+                order = order(1, 2, 3),
+                method = Method.GET,
+                queryParams = params(
+                        "sources" to "crypto-coins-news",
+                        "apiKey" to "a7c816f57c004c49a21bd458e11e2807"),
+                headers = headers("Cache-Control" to "max-age=640000"))
     }
 
-    server.verify("v2/top-headlines").called(
-        times = times(3),
-        order = order(1, 2, 3),
-        method = Method.GET,
-        queryParams = params(
-            "sources" to "crypto-coins-news",
-            "apiKey" to "a7c816f57c004c49a21bd458e11e2807"),
-        headers = headers("Cache-Control" to "max-age=640000"))
-  }
+    @Test
+    fun verifiesAtLeast() {
+        server.whenever(Method.GET, "v2/top-headlines")
+                .thenRespond(success(jsonBody = fileBody("GetNews.json")))
+                .thenRespond(success(jsonBody = fileBody("GetNews.json")))
+                .thenRespond(success(jsonBody = fileBody("GetNews.json")))
 
-  @Test
-  fun verifiesAtLeast() {
-    server.whenever(Method.GET, "v2/top-headlines")
-        .thenRespond(success(jsonBody = fileBody("GetNews.json")))
-        .thenRespond(success(jsonBody = fileBody("GetNews.json")))
-        .thenRespond(success(jsonBody = fileBody("GetNews.json")))
+        runBlocking {
+            dataSource.getNews()
+            dataSource.getNews()
+            dataSource.getNews()
+        }
 
-    runBlocking {
-      dataSource.getNews()
-      dataSource.getNews()
-      dataSource.getNews()
+        server.verify("v2/top-headlines").called(times = atLeast(3))
     }
 
-    server.verify("v2/top-headlines").called(times = atLeast(3))
-  }
+    @Test
+    fun verifiesAtLeast2() {
+        server.whenever(Method.GET, "v2/top-headlines")
+                .thenRespond(success(jsonBody = fileBody("GetNews.json")))
+                .thenRespond(success(jsonBody = fileBody("GetNews.json")))
+                .thenRespond(success(jsonBody = fileBody("GetNews.json")))
 
-  @Test
-  fun verifiesAtLeast2() {
-    server.whenever(Method.GET, "v2/top-headlines")
-        .thenRespond(success(jsonBody = fileBody("GetNews.json")))
-        .thenRespond(success(jsonBody = fileBody("GetNews.json")))
-        .thenRespond(success(jsonBody = fileBody("GetNews.json")))
+        runBlocking {
+            dataSource.getNews()
+            dataSource.getNews()
+            dataSource.getNews()
+        }
 
-    runBlocking {
-      dataSource.getNews()
-      dataSource.getNews()
-      dataSource.getNews()
+        server.verify("v2/top-headlines").called(times = atLeast(1))
     }
 
-    server.verify("v2/top-headlines").called(times = atLeast(1))
-  }
+    @Test(expected = AssertionError::class)
+    fun verifiesAtLeastError() {
+        server.whenever(Method.GET, "v2/top-headlines")
+                .thenRespond(success(jsonBody = fileBody("GetNews.json")))
+                .thenRespond(success(jsonBody = fileBody("GetNews.json")))
+                .thenRespond(success(jsonBody = fileBody("GetNews.json")))
 
-  @Test(expected = AssertionError::class)
-  fun verifiesAtLeastError() {
-    server.whenever(Method.GET, "v2/top-headlines")
-        .thenRespond(success(jsonBody = fileBody("GetNews.json")))
-        .thenRespond(success(jsonBody = fileBody("GetNews.json")))
-        .thenRespond(success(jsonBody = fileBody("GetNews.json")))
+        runBlocking {
+            dataSource.getNews()
+            dataSource.getNews()
+            dataSource.getNews()
+        }
 
-    runBlocking {
-      dataSource.getNews()
-      dataSource.getNews()
-      dataSource.getNews()
+        server.verify("v2/top-headlines").called(times = atLeast(4))
     }
 
-    server.verify("v2/top-headlines").called(times = atLeast(4))
-  }
+    @Test
+    fun verifiesAtMost() {
+        server.whenever(Method.GET, "v2/top-headlines")
+                .thenRespond(success(jsonBody = fileBody("GetNews.json")))
+                .thenRespond(success(jsonBody = fileBody("GetNews.json")))
+                .thenRespond(success(jsonBody = fileBody("GetNews.json")))
 
-  @Test
-  fun verifiesAtMost() {
-    server.whenever(Method.GET, "v2/top-headlines")
-        .thenRespond(success(jsonBody = fileBody("GetNews.json")))
-        .thenRespond(success(jsonBody = fileBody("GetNews.json")))
-        .thenRespond(success(jsonBody = fileBody("GetNews.json")))
+        runBlocking {
+            dataSource.getNews()
+            dataSource.getNews()
+            dataSource.getNews()
+        }
 
-    runBlocking {
-      dataSource.getNews()
-      dataSource.getNews()
-      dataSource.getNews()
+        server.verify("v2/top-headlines").called(times = atMost(3))
     }
 
-    server.verify("v2/top-headlines").called(times = atMost(3))
-  }
+    @Test
+    fun verifiesAtMost2() {
+        server.whenever(Method.GET, "v2/top-headlines")
+                .thenRespond(success(jsonBody = fileBody("GetNews.json")))
+                .thenRespond(success(jsonBody = fileBody("GetNews.json")))
+                .thenRespond(success(jsonBody = fileBody("GetNews.json")))
 
-  @Test
-  fun verifiesAtMost2() {
-    server.whenever(Method.GET, "v2/top-headlines")
-        .thenRespond(success(jsonBody = fileBody("GetNews.json")))
-        .thenRespond(success(jsonBody = fileBody("GetNews.json")))
-        .thenRespond(success(jsonBody = fileBody("GetNews.json")))
+        runBlocking {
+            dataSource.getNews()
+            dataSource.getNews()
+            dataSource.getNews()
+        }
 
-    runBlocking {
-      dataSource.getNews()
-      dataSource.getNews()
-      dataSource.getNews()
+        server.verify("v2/top-headlines").called(times = atMost(4))
     }
 
-    server.verify("v2/top-headlines").called(times = atMost(4))
-  }
+    @Test(expected = AssertionError::class)
+    fun verifiesAtMostError() {
+        server.whenever(Method.GET, "v2/top-headlines")
+                .thenRespond(success(jsonBody = fileBody("GetNews.json")))
+                .thenRespond(success(jsonBody = fileBody("GetNews.json")))
+                .thenRespond(success(jsonBody = fileBody("GetNews.json")))
 
-  @Test(expected = AssertionError::class)
-  fun verifiesAtMostError() {
-    server.whenever(Method.GET, "v2/top-headlines")
-        .thenRespond(success(jsonBody = fileBody("GetNews.json")))
-        .thenRespond(success(jsonBody = fileBody("GetNews.json")))
-        .thenRespond(success(jsonBody = fileBody("GetNews.json")))
+        runBlocking {
+            dataSource.getNews()
+            dataSource.getNews()
+            dataSource.getNews()
+        }
 
-    runBlocking {
-      dataSource.getNews()
-      dataSource.getNews()
-      dataSource.getNews()
+        server.verify("v2/top-headlines").called(times = atMost(2))
     }
 
-    server.verify("v2/top-headlines").called(times = atMost(2))
-  }
+    @Test(expected = AssertionError::class)
+    fun verifiesNeverError() {
+        server.whenever(Method.GET, "v2/top-headlines")
+                .thenRespond(success(jsonBody = fileBody("GetNews.json")))
+                .thenRespond(success(jsonBody = fileBody("GetNews.json")))
+                .thenRespond(success(jsonBody = fileBody("GetNews.json")))
 
-  @Test(expected = AssertionError::class)
-  fun verifiesNeverError() {
-    server.whenever(Method.GET, "v2/top-headlines")
-        .thenRespond(success(jsonBody = fileBody("GetNews.json")))
-        .thenRespond(success(jsonBody = fileBody("GetNews.json")))
-        .thenRespond(success(jsonBody = fileBody("GetNews.json")))
+        runBlocking {
+            dataSource.getNews()
+            dataSource.getNews()
+            dataSource.getNews()
+        }
 
-    runBlocking {
-      dataSource.getNews()
-      dataSource.getNews()
-      dataSource.getNews()
+        server.verify("v2/top-headlines").called(times = never())
     }
 
-    server.verify("v2/top-headlines").called(times = never())
-  }
+    @Test
+    fun verifiesNever() {
+        server.whenever(Method.GET, "v2/top-headlines")
+                .thenRespond(success(jsonBody = fileBody("GetNews.json")))
+                .thenRespond(success(jsonBody = fileBody("GetNews.json")))
+                .thenRespond(success(jsonBody = fileBody("GetNews.json")))
 
-  @Test
-  fun verifiesNever() {
-    server.whenever(Method.GET, "v2/top-headlines")
-        .thenRespond(success(jsonBody = fileBody("GetNews.json")))
-        .thenRespond(success(jsonBody = fileBody("GetNews.json")))
-        .thenRespond(success(jsonBody = fileBody("GetNews.json")))
+        runBlocking {
+            dataSource.getNews()
+            dataSource.getNews()
+            dataSource.getNews()
+        }
 
-    runBlocking {
-      dataSource.getNews()
-      dataSource.getNews()
-      dataSource.getNews()
+        server.verify("v2/users").called(times = never())
     }
 
-    server.verify("v2/users").called(times = never())
-  }
-
-  private fun expectedNews(): List<Article> {
-    return listOf(
-        Article(
-            "How to Get Android P's Screenshot Editing Tool on Any Android Phone",
-            "Last year, Apple brought advanced screenshot editing tools to the iPhone with iOS 11, and, this week, Google fired back with a similar Android feature called Markup. The only catch is that this new tool is limited to Android P, which launches later this year …",
-            "https://lifehacker.com/how-to-get-android-ps-screenshot-editing-tool-on-any-an-1823646122",
-            "https://i.kinja-img.com/gawker-media/image/upload/s--Y-5X_NcT--/c_fill,fl_progressive,g_center,h_450,q_80,w_800/nxmwbkwzoc1z1tmak7s4.jpg",
-            "2018-03-09T20:30:00Z",
-            Source(null, "Lifehacker.com")
-        ),
-        Article(
-            "Capital One's virtual credit cards could help you avoid fraud",
-            "Capital One is no stranger to trying new things -- especially when it comes to technology. Its Eno texting chatbot, for example, is a quick and conversational way for its customers to check their balances and perform simple tasks, like checking on recent tran…",
-            "https://www.engadget.com/2018/03/09/capital-one-virtual-credit-cards/",
-            "https://o.aolcdn.com/images/dims?thumbnail=1200%2C630&quality=80&image_uri=https%3A%2F%2Fo.aolcdn.com%2Fimages%2Fdims%3Fcrop%3D3861%252C2574%252C0%252C0%26quality%3D85%26format%3Djpg%26resize%3D1600%252C1067%26image_uri%3Dhttp%253A%252F%252Fo.aolcdn.com%252Fhss%252Fstorage%252Fmidas%252Fca9d74d8d57677d4f3291ae4347b26da%252F206197048%252Fcapital-one-financial-corp-signage-is-displayed-at-a-bank-branch-in-picture-id120933061%26client%3Da1acac3e1b3290917d92%26signature%3Db51d9958f8487452f6a8c6d354650fcb339f0520&client=cbc79c14efcebee57402&signature=44e59feb505c1b9c4e5867d453d3ed345010acac",
-            "2018-03-09T13:00:00Z",
-            Source("engadget", "Engadget")
-        ),
-        Article(
-            "Magic Leap gets \$461M more, Travis goes VC, and HQ Trivia scales up",
-            "Hello and welcome back to Equity, TechCrunch’s venture capital-focused podcast where we unpack the numbers behind the headlines. This week we had a corking set of news to get through, so we rounded up the usual gang (Matthew Lynley, Katie Roof, and myself), a…",
-            "http://techcrunch.com/2018/03/09/magic-leap-gets-461m-more-travis-goes-vc-and-hq-trivia-scales-up/",
-            "https://tctechcrunch2011.files.wordpress.com/2017/03/tc-equity-podcast-ios.jpg",
-            "2018-03-09T14:10:01Z",
-            Source("techcrunch", "TechCrunch")
+    private fun expectedNews(): List<Article> {
+        return listOf(
+                Article(
+                        "How to Get Android P's Screenshot Editing Tool on Any Android Phone",
+                        "Last year, Apple brought advanced screenshot editing tools to the iPhone with iOS 11, and, this week, Google fired back with a similar Android feature called Markup. The only catch is that this new tool is limited to Android P, which launches later this year …",
+                        "https://lifehacker.com/how-to-get-android-ps-screenshot-editing-tool-on-any-an-1823646122",
+                        "https://i.kinja-img.com/gawker-media/image/upload/s--Y-5X_NcT--/c_fill,fl_progressive,g_center,h_450,q_80,w_800/nxmwbkwzoc1z1tmak7s4.jpg",
+                        "2018-03-09T20:30:00Z",
+                        Source(null, "Lifehacker.com")
+                ),
+                Article(
+                        "Capital One's virtual credit cards could help you avoid fraud",
+                        "Capital One is no stranger to trying new things -- especially when it comes to technology. Its Eno texting chatbot, for example, is a quick and conversational way for its customers to check their balances and perform simple tasks, like checking on recent tran…",
+                        "https://www.engadget.com/2018/03/09/capital-one-virtual-credit-cards/",
+                        "https://o.aolcdn.com/images/dims?thumbnail=1200%2C630&quality=80&image_uri=https%3A%2F%2Fo.aolcdn.com%2Fimages%2Fdims%3Fcrop%3D3861%252C2574%252C0%252C0%26quality%3D85%26format%3Djpg%26resize%3D1600%252C1067%26image_uri%3Dhttp%253A%252F%252Fo.aolcdn.com%252Fhss%252Fstorage%252Fmidas%252Fca9d74d8d57677d4f3291ae4347b26da%252F206197048%252Fcapital-one-financial-corp-signage-is-displayed-at-a-bank-branch-in-picture-id120933061%26client%3Da1acac3e1b3290917d92%26signature%3Db51d9958f8487452f6a8c6d354650fcb339f0520&client=cbc79c14efcebee57402&signature=44e59feb505c1b9c4e5867d453d3ed345010acac",
+                        "2018-03-09T13:00:00Z",
+                        Source("engadget", "Engadget")
+                ),
+                Article(
+                        "Magic Leap gets \$461M more, Travis goes VC, and HQ Trivia scales up",
+                        "Hello and welcome back to Equity, TechCrunch’s venture capital-focused podcast where we unpack the numbers behind the headlines. This week we had a corking set of news to get through, so we rounded up the usual gang (Matthew Lynley, Katie Roof, and myself), a…",
+                        "http://techcrunch.com/2018/03/09/magic-leap-gets-461m-more-travis-goes-vc-and-hq-trivia-scales-up/",
+                        "https://tctechcrunch2011.files.wordpress.com/2017/03/tc-equity-podcast-ios.jpg",
+                        "2018-03-09T14:10:01Z",
+                        Source("techcrunch", "TechCrunch")
+                )
         )
-    )
-  }
+    }
 
-  private fun expectedSingleNew(requestPathLengthAsSourceId: Int? = null): List<Article> = listOf(
-      Article(
-          "How to Get Android P's Screenshot Editing Tool on Any Android Phone",
-          "Last year, Apple brought advanced screenshot editing tools to the iPhone with iOS 11, and, this week, Google fired back with a similar Android feature called Markup. The only catch is that this new tool is limited to Android P, which launches later this year …",
-          "https://lifehacker.com/how-to-get-android-ps-screenshot-editing-tool-on-any-an-1823646122",
-          "https://i.kinja-img.com/gawker-media/image/upload/s--Y-5X_NcT--/c_fill,fl_progressive,g_center,h_450,q_80,w_800/nxmwbkwzoc1z1tmak7s4.jpg",
-          "2018-03-09T20:30:00Z",
-          Source(
-              if (requestPathLengthAsSourceId != null) "$requestPathLengthAsSourceId" else null,
-              "Lifehacker.com"
-          )
-      )
-  )
+    private fun expectedSingleNew(requestPathLengthAsSourceId: Int? = null): List<Article> = listOf(
+            Article(
+                    "How to Get Android P's Screenshot Editing Tool on Any Android Phone",
+                    "Last year, Apple brought advanced screenshot editing tools to the iPhone with iOS 11, and, this week, Google fired back with a similar Android feature called Markup. The only catch is that this new tool is limited to Android P, which launches later this year …",
+                    "https://lifehacker.com/how-to-get-android-ps-screenshot-editing-tool-on-any-an-1823646122",
+                    "https://i.kinja-img.com/gawker-media/image/upload/s--Y-5X_NcT--/c_fill,fl_progressive,g_center,h_450,q_80,w_800/nxmwbkwzoc1z1tmak7s4.jpg",
+                    "2018-03-09T20:30:00Z",
+                    Source(
+                            if (requestPathLengthAsSourceId != null) "$requestPathLengthAsSourceId" else null,
+                            "Lifehacker.com"
+                    )
+            )
+    )
 }

--- a/app/src/test/java/me/jorgecastillo/hiroaki/MoshiNewsNetworkDataSourceTest.kt
+++ b/app/src/test/java/me/jorgecastillo/hiroaki/MoshiNewsNetworkDataSourceTest.kt
@@ -1,6 +1,6 @@
 package me.jorgecastillo.hiroaki
 
-import kotlinx.coroutines.experimental.runBlocking
+import kotlinx.coroutines.runBlocking
 import me.jorgecastillo.hiroaki.Method.GET
 import me.jorgecastillo.hiroaki.Method.POST
 import me.jorgecastillo.hiroaki.data.datasource.MoshiNewsNetworkDataSource
@@ -8,12 +8,7 @@ import me.jorgecastillo.hiroaki.data.service.MoshiNewsApiService
 import me.jorgecastillo.hiroaki.internal.MockServerSuite
 import me.jorgecastillo.hiroaki.model.Article
 import me.jorgecastillo.hiroaki.model.Source
-import me.jorgecastillo.hiroaki.models.error
-import me.jorgecastillo.hiroaki.models.fileBody
-import me.jorgecastillo.hiroaki.models.inlineBody
-import me.jorgecastillo.hiroaki.models.json
-import me.jorgecastillo.hiroaki.models.jsonArray
-import me.jorgecastillo.hiroaki.models.success
+import me.jorgecastillo.hiroaki.models.*
 import me.jorgecastillo.hiroaki.mother.anyArticle
 import org.junit.Before
 import org.junit.Test
@@ -25,156 +20,156 @@ import java.io.IOException
 @RunWith(MockitoJUnitRunner::class)
 class MoshiNewsNetworkDataSourceTest : MockServerSuite() {
 
-    private lateinit var dataSource: MoshiNewsNetworkDataSource
+  private lateinit var dataSource: MoshiNewsNetworkDataSource
 
-    @Before
-    override fun setup() {
-        super.setup()
-        dataSource = MoshiNewsNetworkDataSource(
-                server.retrofitService(
-                        MoshiNewsApiService::class.java,
-                        MoshiConverterFactory.create()
-                )
+  @Before
+  override fun setup() {
+    super.setup()
+    dataSource = MoshiNewsNetworkDataSource(
+        server.retrofitService(
+            MoshiNewsApiService::class.java,
+            MoshiConverterFactory.create()
         )
-    }
-
-    @Test
-    fun sendsGetNews() {
-        server.whenever(GET, "v2/top-headlines")
-                .thenRespond(success(jsonBody = fileBody("GetNews.json")))
-
-        runBlocking { dataSource.getNews() }
-
-        server.verify("v2/top-headlines").called(
-                times = once(),
-                queryParams = params(
-                        "sources" to "crypto-coins-news",
-                        "apiKey" to "a7c816f57c004c49a21bd458e11e2807"),
-                headers = headers(
-                        "Cache-Control" to "max-age=640000"
-                ),
-                method = GET)
-    }
-
-    @Test
-    fun sendsPublishHeadline() {
-        server.whenever(POST, "v2/top-headlines").thenRespond(success())
-        val article = anyArticle()
-
-        runBlocking { dataSource.publishHeadline(article) }
-
-        server.verify("v2/top-headlines").called(
-                times = once(),
-                jsonBody = fileBody("PublishHeadline.json"),
-                method = POST)
-    }
-
-    @Test
-    fun sendsPublishHeadlineUsingInlineBody() {
-        server.whenever(POST, "v2/top-headlines").thenRespond(success())
-        val article = anyArticle()
-
-        runBlocking { dataSource.publishHeadline(article) }
-
-        server.verify("v2/top-headlines").called(
-                times = once(),
-                jsonBody = inlineBody("{\n" +
-                        "  \"title\": \"Any Title\",\n" +
-                        "  \"description\": \"Any description\",\n" +
-                        "  \"url\": \"http://any.url\",\n" +
-                        "  \"urlToImage\": \"http://any.url/any_image.png\",\n" +
-                        "  \"publishedAt\": \"2018-03-10T14:09:00Z\",\n" +
-                        "  \"source\": {\n" +
-                        "    \"id\": \"AnyId\",\n" +
-                        "    \"name\": \"ANYID\"\n" +
-                        "  }\n" +
-                        "}\n"))
-    }
-
-    @Test
-    fun parsesNewsProperly() {
-        server.whenever(GET, "v2/top-headlines")
-                .thenRespond(success(jsonBody = fileBody("GetNews.json")))
-
-        val news = runBlocking { dataSource.getNews() }
-
-        news eq expectedNews()
-    }
-
-    @Test(expected = IOException::class)
-    fun throwsIOExceptionOnGetNewsErrorResponse() {
-        server.whenever(GET, "v2/top-headlines").thenRespond(error())
-
-        runBlocking { dataSource.getNews() }
-    }
-
-    @Test
-    fun respondsJsonDSLNestedJson() {
-        server.whenever(Method.GET, "v2/top-headlines")
-                .thenDispatch { request ->
-                    success(jsonBody = json {
-                        "status" / "ok"
-                        "totalResults" / 2342
-                        "articles" / jsonArray(json {
-                            "source" / json {
-                                "id" / request.path.length
-                                "name" / "Lifehacker.com"
-                            }
-                            "author" / "Jacob Kleinman"
-                            "title" / "How to Get Android P's Screenshot Editing Tool on Any Android Phone"
-                            "description" / "Last year, Apple brought advanced screenshot editing tools to the iPhone with iOS 11, and, this week, Google fired back with a similar Android feature called Markup. The only catch is that this new tool is limited to Android P, which launches later this year …"
-                            "url" / "https://lifehacker.com/how-to-get-android-ps-screenshot-editing-tool-on-any-an-1823646122"
-                            "urlToImage" / "https://i.kinja-img.com/gawker-media/image/upload/s--Y-5X_NcT--/c_fill,fl_progressive,g_center,h_450,q_80,w_800/nxmwbkwzoc1z1tmak7s4.jpg"
-                            "publishedAt" / "2018-03-09T20:30:00Z"
-                        })
-                    })
-                }
-
-        val singleNew = runBlocking { dataSource.getNews() }
-
-        singleNew eq expectedSingleNew(83)
-    }
-
-    private fun expectedNews(): List<Article> {
-        return listOf(
-                Article(
-                        "How to Get Android P's Screenshot Editing Tool on Any Android Phone",
-                        "Last year, Apple brought advanced screenshot editing tools to the iPhone with iOS 11, and, this week, Google fired back with a similar Android feature called Markup. The only catch is that this new tool is limited to Android P, which launches later this year …",
-                        "https://lifehacker.com/how-to-get-android-ps-screenshot-editing-tool-on-any-an-1823646122",
-                        "https://i.kinja-img.com/gawker-media/image/upload/s--Y-5X_NcT--/c_fill,fl_progressive,g_center,h_450,q_80,w_800/nxmwbkwzoc1z1tmak7s4.jpg",
-                        "2018-03-09T20:30:00Z",
-                        Source(null, "Lifehacker.com")
-                ),
-                Article(
-                        "Capital One's virtual credit cards could help you avoid fraud",
-                        "Capital One is no stranger to trying new things -- especially when it comes to technology. Its Eno texting chatbot, for example, is a quick and conversational way for its customers to check their balances and perform simple tasks, like checking on recent tran…",
-                        "https://www.engadget.com/2018/03/09/capital-one-virtual-credit-cards/",
-                        "https://o.aolcdn.com/images/dims?thumbnail=1200%2C630&quality=80&image_uri=https%3A%2F%2Fo.aolcdn.com%2Fimages%2Fdims%3Fcrop%3D3861%252C2574%252C0%252C0%26quality%3D85%26format%3Djpg%26resize%3D1600%252C1067%26image_uri%3Dhttp%253A%252F%252Fo.aolcdn.com%252Fhss%252Fstorage%252Fmidas%252Fca9d74d8d57677d4f3291ae4347b26da%252F206197048%252Fcapital-one-financial-corp-signage-is-displayed-at-a-bank-branch-in-picture-id120933061%26client%3Da1acac3e1b3290917d92%26signature%3Db51d9958f8487452f6a8c6d354650fcb339f0520&client=cbc79c14efcebee57402&signature=44e59feb505c1b9c4e5867d453d3ed345010acac",
-                        "2018-03-09T13:00:00Z",
-                        Source("engadget", "Engadget")
-                ),
-                Article(
-                        "Magic Leap gets \$461M more, Travis goes VC, and HQ Trivia scales up",
-                        "Hello and welcome back to Equity, TechCrunch’s venture capital-focused podcast where we unpack the numbers behind the headlines. This week we had a corking set of news to get through, so we rounded up the usual gang (Matthew Lynley, Katie Roof, and myself), a…",
-                        "http://techcrunch.com/2018/03/09/magic-leap-gets-461m-more-travis-goes-vc-and-hq-trivia-scales-up/",
-                        "https://tctechcrunch2011.files.wordpress.com/2017/03/tc-equity-podcast-ios.jpg",
-                        "2018-03-09T14:10:01Z",
-                        Source("techcrunch", "TechCrunch")
-                )
-        )
-    }
-
-    fun expectedSingleNew(requestPathLengthAsSourceId: Int? = null): List<Article> = listOf(
-            Article(
-                    "How to Get Android P's Screenshot Editing Tool on Any Android Phone",
-                    "Last year, Apple brought advanced screenshot editing tools to the iPhone with iOS 11, and, this week, Google fired back with a similar Android feature called Markup. The only catch is that this new tool is limited to Android P, which launches later this year …",
-                    "https://lifehacker.com/how-to-get-android-ps-screenshot-editing-tool-on-any-an-1823646122",
-                    "https://i.kinja-img.com/gawker-media/image/upload/s--Y-5X_NcT--/c_fill,fl_progressive,g_center,h_450,q_80,w_800/nxmwbkwzoc1z1tmak7s4.jpg",
-                    "2018-03-09T20:30:00Z",
-                    Source(
-                            if (requestPathLengthAsSourceId != null) "$requestPathLengthAsSourceId" else null,
-                            "Lifehacker.com"
-                    )
-            )
     )
+  }
+
+  @Test
+  fun sendsGetNews() {
+    server.whenever(GET, "v2/top-headlines")
+        .thenRespond(success(jsonBody = fileBody("GetNews.json")))
+
+    runBlocking { dataSource.getNews() }
+
+    server.verify("v2/top-headlines").called(
+        times = once(),
+        queryParams = params(
+            "sources" to "crypto-coins-news",
+            "apiKey" to "a7c816f57c004c49a21bd458e11e2807"),
+        headers = headers(
+            "Cache-Control" to "max-age=640000"
+        ),
+        method = GET)
+  }
+
+  @Test
+  fun sendsPublishHeadline() {
+    server.whenever(POST, "v2/top-headlines").thenRespond(success())
+    val article = anyArticle()
+
+    runBlocking { dataSource.publishHeadline(article) }
+
+    server.verify("v2/top-headlines").called(
+        times = once(),
+        jsonBody = fileBody("PublishHeadline.json"),
+        method = POST)
+  }
+
+  @Test
+  fun sendsPublishHeadlineUsingInlineBody() {
+    server.whenever(POST, "v2/top-headlines").thenRespond(success())
+    val article = anyArticle()
+
+    runBlocking { dataSource.publishHeadline(article) }
+
+    server.verify("v2/top-headlines").called(
+        times = once(),
+        jsonBody = inlineBody("{\n" +
+            "  \"title\": \"Any Title\",\n" +
+            "  \"description\": \"Any description\",\n" +
+            "  \"url\": \"http://any.url\",\n" +
+            "  \"urlToImage\": \"http://any.url/any_image.png\",\n" +
+            "  \"publishedAt\": \"2018-03-10T14:09:00Z\",\n" +
+            "  \"source\": {\n" +
+            "    \"id\": \"AnyId\",\n" +
+            "    \"name\": \"ANYID\"\n" +
+            "  }\n" +
+            "}\n"))
+  }
+
+  @Test
+  fun parsesNewsProperly() {
+    server.whenever(GET, "v2/top-headlines")
+        .thenRespond(success(jsonBody = fileBody("GetNews.json")))
+
+    val news = runBlocking { dataSource.getNews() }
+
+    news eq expectedNews()
+  }
+
+  @Test(expected = IOException::class)
+  fun throwsIOExceptionOnGetNewsErrorResponse() {
+    server.whenever(GET, "v2/top-headlines").thenRespond(error())
+
+    runBlocking { dataSource.getNews() }
+  }
+
+  @Test
+  fun respondsJsonDSLNestedJson() {
+    server.whenever(Method.GET, "v2/top-headlines")
+        .thenDispatch { request ->
+          success(jsonBody = json {
+            "status" / "ok"
+            "totalResults" / 2342
+            "articles" / jsonArray(json {
+              "source" / json {
+                "id" / request.path.length
+                "name" / "Lifehacker.com"
+              }
+              "author" / "Jacob Kleinman"
+              "title" / "How to Get Android P's Screenshot Editing Tool on Any Android Phone"
+              "description" / "Last year, Apple brought advanced screenshot editing tools to the iPhone with iOS 11, and, this week, Google fired back with a similar Android feature called Markup. The only catch is that this new tool is limited to Android P, which launches later this year …"
+              "url" / "https://lifehacker.com/how-to-get-android-ps-screenshot-editing-tool-on-any-an-1823646122"
+              "urlToImage" / "https://i.kinja-img.com/gawker-media/image/upload/s--Y-5X_NcT--/c_fill,fl_progressive,g_center,h_450,q_80,w_800/nxmwbkwzoc1z1tmak7s4.jpg"
+              "publishedAt" / "2018-03-09T20:30:00Z"
+            })
+          })
+        }
+
+    val singleNew = runBlocking { dataSource.getNews() }
+
+    singleNew eq expectedSingleNew(83)
+  }
+
+  private fun expectedNews(): List<Article> {
+    return listOf(
+        Article(
+            "How to Get Android P's Screenshot Editing Tool on Any Android Phone",
+            "Last year, Apple brought advanced screenshot editing tools to the iPhone with iOS 11, and, this week, Google fired back with a similar Android feature called Markup. The only catch is that this new tool is limited to Android P, which launches later this year …",
+            "https://lifehacker.com/how-to-get-android-ps-screenshot-editing-tool-on-any-an-1823646122",
+            "https://i.kinja-img.com/gawker-media/image/upload/s--Y-5X_NcT--/c_fill,fl_progressive,g_center,h_450,q_80,w_800/nxmwbkwzoc1z1tmak7s4.jpg",
+            "2018-03-09T20:30:00Z",
+            Source(null, "Lifehacker.com")
+        ),
+        Article(
+            "Capital One's virtual credit cards could help you avoid fraud",
+            "Capital One is no stranger to trying new things -- especially when it comes to technology. Its Eno texting chatbot, for example, is a quick and conversational way for its customers to check their balances and perform simple tasks, like checking on recent tran…",
+            "https://www.engadget.com/2018/03/09/capital-one-virtual-credit-cards/",
+            "https://o.aolcdn.com/images/dims?thumbnail=1200%2C630&quality=80&image_uri=https%3A%2F%2Fo.aolcdn.com%2Fimages%2Fdims%3Fcrop%3D3861%252C2574%252C0%252C0%26quality%3D85%26format%3Djpg%26resize%3D1600%252C1067%26image_uri%3Dhttp%253A%252F%252Fo.aolcdn.com%252Fhss%252Fstorage%252Fmidas%252Fca9d74d8d57677d4f3291ae4347b26da%252F206197048%252Fcapital-one-financial-corp-signage-is-displayed-at-a-bank-branch-in-picture-id120933061%26client%3Da1acac3e1b3290917d92%26signature%3Db51d9958f8487452f6a8c6d354650fcb339f0520&client=cbc79c14efcebee57402&signature=44e59feb505c1b9c4e5867d453d3ed345010acac",
+            "2018-03-09T13:00:00Z",
+            Source("engadget", "Engadget")
+        ),
+        Article(
+            "Magic Leap gets \$461M more, Travis goes VC, and HQ Trivia scales up",
+            "Hello and welcome back to Equity, TechCrunch’s venture capital-focused podcast where we unpack the numbers behind the headlines. This week we had a corking set of news to get through, so we rounded up the usual gang (Matthew Lynley, Katie Roof, and myself), a…",
+            "http://techcrunch.com/2018/03/09/magic-leap-gets-461m-more-travis-goes-vc-and-hq-trivia-scales-up/",
+            "https://tctechcrunch2011.files.wordpress.com/2017/03/tc-equity-podcast-ios.jpg",
+            "2018-03-09T14:10:01Z",
+            Source("techcrunch", "TechCrunch")
+        )
+    )
+  }
+
+  fun expectedSingleNew(requestPathLengthAsSourceId: Int? = null): List<Article> = listOf(
+      Article(
+          "How to Get Android P's Screenshot Editing Tool on Any Android Phone",
+          "Last year, Apple brought advanced screenshot editing tools to the iPhone with iOS 11, and, this week, Google fired back with a similar Android feature called Markup. The only catch is that this new tool is limited to Android P, which launches later this year …",
+          "https://lifehacker.com/how-to-get-android-ps-screenshot-editing-tool-on-any-an-1823646122",
+          "https://i.kinja-img.com/gawker-media/image/upload/s--Y-5X_NcT--/c_fill,fl_progressive,g_center,h_450,q_80,w_800/nxmwbkwzoc1z1tmak7s4.jpg",
+          "2018-03-09T20:30:00Z",
+          Source(
+              if (requestPathLengthAsSourceId != null) "$requestPathLengthAsSourceId" else null,
+              "Lifehacker.com"
+          )
+      )
+  )
 }

--- a/app/src/test/java/me/jorgecastillo/hiroaki/MoshiNewsNetworkDataSourceTest.kt
+++ b/app/src/test/java/me/jorgecastillo/hiroaki/MoshiNewsNetworkDataSourceTest.kt
@@ -8,7 +8,12 @@ import me.jorgecastillo.hiroaki.data.service.MoshiNewsApiService
 import me.jorgecastillo.hiroaki.internal.MockServerSuite
 import me.jorgecastillo.hiroaki.model.Article
 import me.jorgecastillo.hiroaki.model.Source
-import me.jorgecastillo.hiroaki.models.*
+import me.jorgecastillo.hiroaki.models.error
+import me.jorgecastillo.hiroaki.models.fileBody
+import me.jorgecastillo.hiroaki.models.inlineBody
+import me.jorgecastillo.hiroaki.models.json
+import me.jorgecastillo.hiroaki.models.jsonArray
+import me.jorgecastillo.hiroaki.models.success
 import me.jorgecastillo.hiroaki.mother.anyArticle
 import org.junit.Before
 import org.junit.Test
@@ -20,156 +25,156 @@ import java.io.IOException
 @RunWith(MockitoJUnitRunner::class)
 class MoshiNewsNetworkDataSourceTest : MockServerSuite() {
 
-  private lateinit var dataSource: MoshiNewsNetworkDataSource
+    private lateinit var dataSource: MoshiNewsNetworkDataSource
 
-  @Before
-  override fun setup() {
-    super.setup()
-    dataSource = MoshiNewsNetworkDataSource(
-        server.retrofitService(
-            MoshiNewsApiService::class.java,
-            MoshiConverterFactory.create()
+    @Before
+    override fun setup() {
+        super.setup()
+        dataSource = MoshiNewsNetworkDataSource(
+            server.retrofitService(
+                MoshiNewsApiService::class.java,
+                MoshiConverterFactory.create()
+            )
         )
-    )
-  }
+    }
 
-  @Test
-  fun sendsGetNews() {
-    server.whenever(GET, "v2/top-headlines")
-        .thenRespond(success(jsonBody = fileBody("GetNews.json")))
+    @Test
+    fun sendsGetNews() {
+        server.whenever(GET, "v2/top-headlines")
+            .thenRespond(success(jsonBody = fileBody("GetNews.json")))
 
-    runBlocking { dataSource.getNews() }
+        runBlocking { dataSource.getNews() }
 
-    server.verify("v2/top-headlines").called(
-        times = once(),
-        queryParams = params(
-            "sources" to "crypto-coins-news",
-            "apiKey" to "a7c816f57c004c49a21bd458e11e2807"),
-        headers = headers(
-            "Cache-Control" to "max-age=640000"
-        ),
-        method = GET)
-  }
+        server.verify("v2/top-headlines").called(
+            times = once(),
+            queryParams = params(
+                "sources" to "crypto-coins-news",
+                "apiKey" to "a7c816f57c004c49a21bd458e11e2807"),
+            headers = headers(
+                "Cache-Control" to "max-age=640000"
+            ),
+            method = GET)
+    }
 
-  @Test
-  fun sendsPublishHeadline() {
-    server.whenever(POST, "v2/top-headlines").thenRespond(success())
-    val article = anyArticle()
+    @Test
+    fun sendsPublishHeadline() {
+        server.whenever(POST, "v2/top-headlines").thenRespond(success())
+        val article = anyArticle()
 
-    runBlocking { dataSource.publishHeadline(article) }
+        runBlocking { dataSource.publishHeadline(article) }
 
-    server.verify("v2/top-headlines").called(
-        times = once(),
-        jsonBody = fileBody("PublishHeadline.json"),
-        method = POST)
-  }
+        server.verify("v2/top-headlines").called(
+            times = once(),
+            jsonBody = fileBody("PublishHeadline.json"),
+            method = POST)
+    }
 
-  @Test
-  fun sendsPublishHeadlineUsingInlineBody() {
-    server.whenever(POST, "v2/top-headlines").thenRespond(success())
-    val article = anyArticle()
+    @Test
+    fun sendsPublishHeadlineUsingInlineBody() {
+        server.whenever(POST, "v2/top-headlines").thenRespond(success())
+        val article = anyArticle()
 
-    runBlocking { dataSource.publishHeadline(article) }
+        runBlocking { dataSource.publishHeadline(article) }
 
-    server.verify("v2/top-headlines").called(
-        times = once(),
-        jsonBody = inlineBody("{\n" +
-            "  \"title\": \"Any Title\",\n" +
-            "  \"description\": \"Any description\",\n" +
-            "  \"url\": \"http://any.url\",\n" +
-            "  \"urlToImage\": \"http://any.url/any_image.png\",\n" +
-            "  \"publishedAt\": \"2018-03-10T14:09:00Z\",\n" +
-            "  \"source\": {\n" +
-            "    \"id\": \"AnyId\",\n" +
-            "    \"name\": \"ANYID\"\n" +
-            "  }\n" +
-            "}\n"))
-  }
+        server.verify("v2/top-headlines").called(
+            times = once(),
+            jsonBody = inlineBody("{\n" +
+                "  \"title\": \"Any Title\",\n" +
+                "  \"description\": \"Any description\",\n" +
+                "  \"url\": \"http://any.url\",\n" +
+                "  \"urlToImage\": \"http://any.url/any_image.png\",\n" +
+                "  \"publishedAt\": \"2018-03-10T14:09:00Z\",\n" +
+                "  \"source\": {\n" +
+                "    \"id\": \"AnyId\",\n" +
+                "    \"name\": \"ANYID\"\n" +
+                "  }\n" +
+                "}\n"))
+    }
 
-  @Test
-  fun parsesNewsProperly() {
-    server.whenever(GET, "v2/top-headlines")
-        .thenRespond(success(jsonBody = fileBody("GetNews.json")))
+    @Test
+    fun parsesNewsProperly() {
+        server.whenever(GET, "v2/top-headlines")
+            .thenRespond(success(jsonBody = fileBody("GetNews.json")))
 
-    val news = runBlocking { dataSource.getNews() }
+        val news = runBlocking { dataSource.getNews() }
 
-    news eq expectedNews()
-  }
+        news eq expectedNews()
+    }
 
-  @Test(expected = IOException::class)
-  fun throwsIOExceptionOnGetNewsErrorResponse() {
-    server.whenever(GET, "v2/top-headlines").thenRespond(error())
+    @Test(expected = IOException::class)
+    fun throwsIOExceptionOnGetNewsErrorResponse() {
+        server.whenever(GET, "v2/top-headlines").thenRespond(error())
 
-    runBlocking { dataSource.getNews() }
-  }
+        runBlocking { dataSource.getNews() }
+    }
 
-  @Test
-  fun respondsJsonDSLNestedJson() {
-    server.whenever(Method.GET, "v2/top-headlines")
-        .thenDispatch { request ->
-          success(jsonBody = json {
-            "status" / "ok"
-            "totalResults" / 2342
-            "articles" / jsonArray(json {
-              "source" / json {
-                "id" / request.path.length
-                "name" / "Lifehacker.com"
-              }
-              "author" / "Jacob Kleinman"
-              "title" / "How to Get Android P's Screenshot Editing Tool on Any Android Phone"
-              "description" / "Last year, Apple brought advanced screenshot editing tools to the iPhone with iOS 11, and, this week, Google fired back with a similar Android feature called Markup. The only catch is that this new tool is limited to Android P, which launches later this year …"
-              "url" / "https://lifehacker.com/how-to-get-android-ps-screenshot-editing-tool-on-any-an-1823646122"
-              "urlToImage" / "https://i.kinja-img.com/gawker-media/image/upload/s--Y-5X_NcT--/c_fill,fl_progressive,g_center,h_450,q_80,w_800/nxmwbkwzoc1z1tmak7s4.jpg"
-              "publishedAt" / "2018-03-09T20:30:00Z"
-            })
-          })
-        }
+    @Test
+    fun respondsJsonDSLNestedJson() {
+        server.whenever(Method.GET, "v2/top-headlines")
+            .thenDispatch { request ->
+                success(jsonBody = json {
+                    "status" / "ok"
+                    "totalResults" / 2342
+                    "articles" / jsonArray(json {
+                        "source" / json {
+                            "id" / request.path.length
+                            "name" / "Lifehacker.com"
+                        }
+                        "author" / "Jacob Kleinman"
+                        "title" / "How to Get Android P's Screenshot Editing Tool on Any Android Phone"
+                        "description" / "Last year, Apple brought advanced screenshot editing tools to the iPhone with iOS 11, and, this week, Google fired back with a similar Android feature called Markup. The only catch is that this new tool is limited to Android P, which launches later this year …"
+                        "url" / "https://lifehacker.com/how-to-get-android-ps-screenshot-editing-tool-on-any-an-1823646122"
+                        "urlToImage" / "https://i.kinja-img.com/gawker-media/image/upload/s--Y-5X_NcT--/c_fill,fl_progressive,g_center,h_450,q_80,w_800/nxmwbkwzoc1z1tmak7s4.jpg"
+                        "publishedAt" / "2018-03-09T20:30:00Z"
+                    })
+                })
+            }
 
-    val singleNew = runBlocking { dataSource.getNews() }
+        val singleNew = runBlocking { dataSource.getNews() }
 
-    singleNew eq expectedSingleNew(83)
-  }
+        singleNew eq expectedSingleNew(83)
+    }
 
-  private fun expectedNews(): List<Article> {
-    return listOf(
+    private fun expectedNews(): List<Article> {
+        return listOf(
+            Article(
+                "How to Get Android P's Screenshot Editing Tool on Any Android Phone",
+                "Last year, Apple brought advanced screenshot editing tools to the iPhone with iOS 11, and, this week, Google fired back with a similar Android feature called Markup. The only catch is that this new tool is limited to Android P, which launches later this year …",
+                "https://lifehacker.com/how-to-get-android-ps-screenshot-editing-tool-on-any-an-1823646122",
+                "https://i.kinja-img.com/gawker-media/image/upload/s--Y-5X_NcT--/c_fill,fl_progressive,g_center,h_450,q_80,w_800/nxmwbkwzoc1z1tmak7s4.jpg",
+                "2018-03-09T20:30:00Z",
+                Source(null, "Lifehacker.com")
+            ),
+            Article(
+                "Capital One's virtual credit cards could help you avoid fraud",
+                "Capital One is no stranger to trying new things -- especially when it comes to technology. Its Eno texting chatbot, for example, is a quick and conversational way for its customers to check their balances and perform simple tasks, like checking on recent tran…",
+                "https://www.engadget.com/2018/03/09/capital-one-virtual-credit-cards/",
+                "https://o.aolcdn.com/images/dims?thumbnail=1200%2C630&quality=80&image_uri=https%3A%2F%2Fo.aolcdn.com%2Fimages%2Fdims%3Fcrop%3D3861%252C2574%252C0%252C0%26quality%3D85%26format%3Djpg%26resize%3D1600%252C1067%26image_uri%3Dhttp%253A%252F%252Fo.aolcdn.com%252Fhss%252Fstorage%252Fmidas%252Fca9d74d8d57677d4f3291ae4347b26da%252F206197048%252Fcapital-one-financial-corp-signage-is-displayed-at-a-bank-branch-in-picture-id120933061%26client%3Da1acac3e1b3290917d92%26signature%3Db51d9958f8487452f6a8c6d354650fcb339f0520&client=cbc79c14efcebee57402&signature=44e59feb505c1b9c4e5867d453d3ed345010acac",
+                "2018-03-09T13:00:00Z",
+                Source("engadget", "Engadget")
+            ),
+            Article(
+                "Magic Leap gets \$461M more, Travis goes VC, and HQ Trivia scales up",
+                "Hello and welcome back to Equity, TechCrunch’s venture capital-focused podcast where we unpack the numbers behind the headlines. This week we had a corking set of news to get through, so we rounded up the usual gang (Matthew Lynley, Katie Roof, and myself), a…",
+                "http://techcrunch.com/2018/03/09/magic-leap-gets-461m-more-travis-goes-vc-and-hq-trivia-scales-up/",
+                "https://tctechcrunch2011.files.wordpress.com/2017/03/tc-equity-podcast-ios.jpg",
+                "2018-03-09T14:10:01Z",
+                Source("techcrunch", "TechCrunch")
+            )
+        )
+    }
+
+    fun expectedSingleNew(requestPathLengthAsSourceId: Int? = null): List<Article> = listOf(
         Article(
             "How to Get Android P's Screenshot Editing Tool on Any Android Phone",
             "Last year, Apple brought advanced screenshot editing tools to the iPhone with iOS 11, and, this week, Google fired back with a similar Android feature called Markup. The only catch is that this new tool is limited to Android P, which launches later this year …",
             "https://lifehacker.com/how-to-get-android-ps-screenshot-editing-tool-on-any-an-1823646122",
             "https://i.kinja-img.com/gawker-media/image/upload/s--Y-5X_NcT--/c_fill,fl_progressive,g_center,h_450,q_80,w_800/nxmwbkwzoc1z1tmak7s4.jpg",
             "2018-03-09T20:30:00Z",
-            Source(null, "Lifehacker.com")
-        ),
-        Article(
-            "Capital One's virtual credit cards could help you avoid fraud",
-            "Capital One is no stranger to trying new things -- especially when it comes to technology. Its Eno texting chatbot, for example, is a quick and conversational way for its customers to check their balances and perform simple tasks, like checking on recent tran…",
-            "https://www.engadget.com/2018/03/09/capital-one-virtual-credit-cards/",
-            "https://o.aolcdn.com/images/dims?thumbnail=1200%2C630&quality=80&image_uri=https%3A%2F%2Fo.aolcdn.com%2Fimages%2Fdims%3Fcrop%3D3861%252C2574%252C0%252C0%26quality%3D85%26format%3Djpg%26resize%3D1600%252C1067%26image_uri%3Dhttp%253A%252F%252Fo.aolcdn.com%252Fhss%252Fstorage%252Fmidas%252Fca9d74d8d57677d4f3291ae4347b26da%252F206197048%252Fcapital-one-financial-corp-signage-is-displayed-at-a-bank-branch-in-picture-id120933061%26client%3Da1acac3e1b3290917d92%26signature%3Db51d9958f8487452f6a8c6d354650fcb339f0520&client=cbc79c14efcebee57402&signature=44e59feb505c1b9c4e5867d453d3ed345010acac",
-            "2018-03-09T13:00:00Z",
-            Source("engadget", "Engadget")
-        ),
-        Article(
-            "Magic Leap gets \$461M more, Travis goes VC, and HQ Trivia scales up",
-            "Hello and welcome back to Equity, TechCrunch’s venture capital-focused podcast where we unpack the numbers behind the headlines. This week we had a corking set of news to get through, so we rounded up the usual gang (Matthew Lynley, Katie Roof, and myself), a…",
-            "http://techcrunch.com/2018/03/09/magic-leap-gets-461m-more-travis-goes-vc-and-hq-trivia-scales-up/",
-            "https://tctechcrunch2011.files.wordpress.com/2017/03/tc-equity-podcast-ios.jpg",
-            "2018-03-09T14:10:01Z",
-            Source("techcrunch", "TechCrunch")
+            Source(
+                if (requestPathLengthAsSourceId != null) "$requestPathLengthAsSourceId" else null,
+                "Lifehacker.com"
+            )
         )
     )
-  }
-
-  fun expectedSingleNew(requestPathLengthAsSourceId: Int? = null): List<Article> = listOf(
-      Article(
-          "How to Get Android P's Screenshot Editing Tool on Any Android Phone",
-          "Last year, Apple brought advanced screenshot editing tools to the iPhone with iOS 11, and, this week, Google fired back with a similar Android feature called Markup. The only catch is that this new tool is limited to Android P, which launches later this year …",
-          "https://lifehacker.com/how-to-get-android-ps-screenshot-editing-tool-on-any-an-1823646122",
-          "https://i.kinja-img.com/gawker-media/image/upload/s--Y-5X_NcT--/c_fill,fl_progressive,g_center,h_450,q_80,w_800/nxmwbkwzoc1z1tmak7s4.jpg",
-          "2018-03-09T20:30:00Z",
-          Source(
-              if (requestPathLengthAsSourceId != null) "$requestPathLengthAsSourceId" else null,
-              "Lifehacker.com"
-          )
-      )
-  )
 }

--- a/app/src/test/java/me/jorgecastillo/hiroaki/RuleNetworkDataSourceTest.kt
+++ b/app/src/test/java/me/jorgecastillo/hiroaki/RuleNetworkDataSourceTest.kt
@@ -1,6 +1,6 @@
 package me.jorgecastillo.hiroaki
 
-import kotlinx.coroutines.experimental.runBlocking
+import kotlinx.coroutines.runBlocking
 import me.jorgecastillo.hiroaki.Method.GET
 import me.jorgecastillo.hiroaki.Method.POST
 import me.jorgecastillo.hiroaki.data.datasource.JacksonNewsNetworkDataSource
@@ -25,115 +25,116 @@ import java.io.IOException
 @RunWith(MockitoJUnitRunner::class)
 class RuleNetworkDataSourceTest {
 
-    private lateinit var dataSource: JacksonNewsNetworkDataSource
-    @get:Rule val rule: MockServerRule = MockServerRule()
+  private lateinit var dataSource: JacksonNewsNetworkDataSource
+  @get:Rule
+  val rule: MockServerRule = MockServerRule()
 
-    @Before
-    fun setup() {
-        dataSource = JacksonNewsNetworkDataSource(
-                rule.server.retrofitService(
-                        JacksonNewsApiService::class.java,
-                        JacksonConverterFactory.create()
-                )
+  @Before
+  fun setup() {
+    dataSource = JacksonNewsNetworkDataSource(
+        rule.server.retrofitService(
+            JacksonNewsApiService::class.java,
+            JacksonConverterFactory.create()
         )
-    }
+    )
+  }
 
-    @Test
-    fun sendsGetNews() {
-        rule.server.whenever(GET, "v2/top-headlines")
-                .thenRespond(success(jsonBody = fileBody("GetNews.json")))
+  @Test
+  fun sendsGetNews() {
+    rule.server.whenever(GET, "v2/top-headlines")
+        .thenRespond(success(jsonBody = fileBody("GetNews.json")))
 
-        runBlocking { dataSource.getNews() }
+    runBlocking { dataSource.getNews() }
 
-        rule.server.verify("v2/top-headlines").called(
-                times = once(),
-                queryParams = params(
-                        "sources" to "crypto-coins-news",
-                        "apiKey" to "a7c816f57c004c49a21bd458e11e2807"),
-                headers = headers(
-                        "Cache-Control" to "max-age=640000"
-                ),
-                method = GET)
-    }
+    rule.server.verify("v2/top-headlines").called(
+        times = once(),
+        queryParams = params(
+            "sources" to "crypto-coins-news",
+            "apiKey" to "a7c816f57c004c49a21bd458e11e2807"),
+        headers = headers(
+            "Cache-Control" to "max-age=640000"
+        ),
+        method = GET)
+  }
 
-    @Test
-    fun sendsPublishHeadline() {
-        rule.server.whenever(POST, "v2/top-headlines").thenRespond(success())
-        val article = anyArticle()
+  @Test
+  fun sendsPublishHeadline() {
+    rule.server.whenever(POST, "v2/top-headlines").thenRespond(success())
+    val article = anyArticle()
 
-        runBlocking { dataSource.publishHeadline(article) }
+    runBlocking { dataSource.publishHeadline(article) }
 
-        rule.server.verify("v2/top-headlines").called(
-                times = once(),
-                jsonBody = fileBody("PublishHeadline.json"),
-                method = POST)
-    }
+    rule.server.verify("v2/top-headlines").called(
+        times = once(),
+        jsonBody = fileBody("PublishHeadline.json"),
+        method = POST)
+  }
 
-    @Test
-    fun sendsPublishHeadlineUsingInlineBody() {
-        rule.server.whenever(POST, "v2/top-headlines").thenRespond(success())
-        val article = anyArticle()
+  @Test
+  fun sendsPublishHeadlineUsingInlineBody() {
+    rule.server.whenever(POST, "v2/top-headlines").thenRespond(success())
+    val article = anyArticle()
 
-        runBlocking { dataSource.publishHeadline(article) }
+    runBlocking { dataSource.publishHeadline(article) }
 
-        rule.server.verify("v2/top-headlines").called(
-                times = times(1),
-                jsonBody = inlineBody("{\n" +
-                        "  \"title\": \"Any Title\",\n" +
-                        "  \"description\": \"Any description\",\n" +
-                        "  \"url\": \"http://any.url\",\n" +
-                        "  \"urlToImage\": \"http://any.url/any_image.png\",\n" +
-                        "  \"publishedAt\": \"2018-03-10T14:09:00Z\",\n" +
-                        "  \"source\": {\n" +
-                        "    \"id\": \"AnyId\",\n" +
-                        "    \"name\": \"ANYID\"\n" +
-                        "  }\n" +
-                        "}\n"))
-    }
+    rule.server.verify("v2/top-headlines").called(
+        times = times(1),
+        jsonBody = inlineBody("{\n" +
+            "  \"title\": \"Any Title\",\n" +
+            "  \"description\": \"Any description\",\n" +
+            "  \"url\": \"http://any.url\",\n" +
+            "  \"urlToImage\": \"http://any.url/any_image.png\",\n" +
+            "  \"publishedAt\": \"2018-03-10T14:09:00Z\",\n" +
+            "  \"source\": {\n" +
+            "    \"id\": \"AnyId\",\n" +
+            "    \"name\": \"ANYID\"\n" +
+            "  }\n" +
+            "}\n"))
+  }
 
-    @Test
-    fun parsesNewsProperly() {
-        rule.server.whenever(GET, "v2/top-headlines")
-                .thenRespond(success(jsonBody = fileBody("GetNews.json")))
+  @Test
+  fun parsesNewsProperly() {
+    rule.server.whenever(GET, "v2/top-headlines")
+        .thenRespond(success(jsonBody = fileBody("GetNews.json")))
 
-        val news = runBlocking { dataSource.getNews() }
+    val news = runBlocking { dataSource.getNews() }
 
-        news eq expectedNews()
-    }
+    news eq expectedNews()
+  }
 
-    @Test(expected = IOException::class)
-    fun throwsIOExceptionOnGetNewsErrorResponse() {
-        rule.server.whenever(GET, "v2/top-headlines").thenRespond(error())
+  @Test(expected = IOException::class)
+  fun throwsIOExceptionOnGetNewsErrorResponse() {
+    rule.server.whenever(GET, "v2/top-headlines").thenRespond(error())
 
-        runBlocking { dataSource.getNews() }
-    }
+    runBlocking { dataSource.getNews() }
+  }
 
-    private fun expectedNews(): List<Article> {
-        return listOf(
-                Article(
-                        "How to Get Android P's Screenshot Editing Tool on Any Android Phone",
-                        "Last year, Apple brought advanced screenshot editing tools to the iPhone with iOS 11, and, this week, Google fired back with a similar Android feature called Markup. The only catch is that this new tool is limited to Android P, which launches later this year …",
-                        "https://lifehacker.com/how-to-get-android-ps-screenshot-editing-tool-on-any-an-1823646122",
-                        "https://i.kinja-img.com/gawker-media/image/upload/s--Y-5X_NcT--/c_fill,fl_progressive,g_center,h_450,q_80,w_800/nxmwbkwzoc1z1tmak7s4.jpg",
-                        "2018-03-09T20:30:00Z",
-                        Source(null, "Lifehacker.com")
-                ),
-                Article(
-                        "Capital One's virtual credit cards could help you avoid fraud",
-                        "Capital One is no stranger to trying new things -- especially when it comes to technology. Its Eno texting chatbot, for example, is a quick and conversational way for its customers to check their balances and perform simple tasks, like checking on recent tran…",
-                        "https://www.engadget.com/2018/03/09/capital-one-virtual-credit-cards/",
-                        "https://o.aolcdn.com/images/dims?thumbnail=1200%2C630&quality=80&image_uri=https%3A%2F%2Fo.aolcdn.com%2Fimages%2Fdims%3Fcrop%3D3861%252C2574%252C0%252C0%26quality%3D85%26format%3Djpg%26resize%3D1600%252C1067%26image_uri%3Dhttp%253A%252F%252Fo.aolcdn.com%252Fhss%252Fstorage%252Fmidas%252Fca9d74d8d57677d4f3291ae4347b26da%252F206197048%252Fcapital-one-financial-corp-signage-is-displayed-at-a-bank-branch-in-picture-id120933061%26client%3Da1acac3e1b3290917d92%26signature%3Db51d9958f8487452f6a8c6d354650fcb339f0520&client=cbc79c14efcebee57402&signature=44e59feb505c1b9c4e5867d453d3ed345010acac",
-                        "2018-03-09T13:00:00Z",
-                        Source("engadget", "Engadget")
-                ),
-                Article(
-                        "Magic Leap gets \$461M more, Travis goes VC, and HQ Trivia scales up",
-                        "Hello and welcome back to Equity, TechCrunch’s venture capital-focused podcast where we unpack the numbers behind the headlines. This week we had a corking set of news to get through, so we rounded up the usual gang (Matthew Lynley, Katie Roof, and myself), a…",
-                        "http://techcrunch.com/2018/03/09/magic-leap-gets-461m-more-travis-goes-vc-and-hq-trivia-scales-up/",
-                        "https://tctechcrunch2011.files.wordpress.com/2017/03/tc-equity-podcast-ios.jpg",
-                        "2018-03-09T14:10:01Z",
-                        Source("techcrunch", "TechCrunch")
-                )
+  private fun expectedNews(): List<Article> {
+    return listOf(
+        Article(
+            "How to Get Android P's Screenshot Editing Tool on Any Android Phone",
+            "Last year, Apple brought advanced screenshot editing tools to the iPhone with iOS 11, and, this week, Google fired back with a similar Android feature called Markup. The only catch is that this new tool is limited to Android P, which launches later this year …",
+            "https://lifehacker.com/how-to-get-android-ps-screenshot-editing-tool-on-any-an-1823646122",
+            "https://i.kinja-img.com/gawker-media/image/upload/s--Y-5X_NcT--/c_fill,fl_progressive,g_center,h_450,q_80,w_800/nxmwbkwzoc1z1tmak7s4.jpg",
+            "2018-03-09T20:30:00Z",
+            Source(null, "Lifehacker.com")
+        ),
+        Article(
+            "Capital One's virtual credit cards could help you avoid fraud",
+            "Capital One is no stranger to trying new things -- especially when it comes to technology. Its Eno texting chatbot, for example, is a quick and conversational way for its customers to check their balances and perform simple tasks, like checking on recent tran…",
+            "https://www.engadget.com/2018/03/09/capital-one-virtual-credit-cards/",
+            "https://o.aolcdn.com/images/dims?thumbnail=1200%2C630&quality=80&image_uri=https%3A%2F%2Fo.aolcdn.com%2Fimages%2Fdims%3Fcrop%3D3861%252C2574%252C0%252C0%26quality%3D85%26format%3Djpg%26resize%3D1600%252C1067%26image_uri%3Dhttp%253A%252F%252Fo.aolcdn.com%252Fhss%252Fstorage%252Fmidas%252Fca9d74d8d57677d4f3291ae4347b26da%252F206197048%252Fcapital-one-financial-corp-signage-is-displayed-at-a-bank-branch-in-picture-id120933061%26client%3Da1acac3e1b3290917d92%26signature%3Db51d9958f8487452f6a8c6d354650fcb339f0520&client=cbc79c14efcebee57402&signature=44e59feb505c1b9c4e5867d453d3ed345010acac",
+            "2018-03-09T13:00:00Z",
+            Source("engadget", "Engadget")
+        ),
+        Article(
+            "Magic Leap gets \$461M more, Travis goes VC, and HQ Trivia scales up",
+            "Hello and welcome back to Equity, TechCrunch’s venture capital-focused podcast where we unpack the numbers behind the headlines. This week we had a corking set of news to get through, so we rounded up the usual gang (Matthew Lynley, Katie Roof, and myself), a…",
+            "http://techcrunch.com/2018/03/09/magic-leap-gets-461m-more-travis-goes-vc-and-hq-trivia-scales-up/",
+            "https://tctechcrunch2011.files.wordpress.com/2017/03/tc-equity-podcast-ios.jpg",
+            "2018-03-09T14:10:01Z",
+            Source("techcrunch", "TechCrunch")
         )
-    }
+    )
+  }
 }

--- a/app/src/test/java/me/jorgecastillo/hiroaki/RuleNetworkDataSourceTest.kt
+++ b/app/src/test/java/me/jorgecastillo/hiroaki/RuleNetworkDataSourceTest.kt
@@ -25,116 +25,116 @@ import java.io.IOException
 @RunWith(MockitoJUnitRunner::class)
 class RuleNetworkDataSourceTest {
 
-  private lateinit var dataSource: JacksonNewsNetworkDataSource
-  @get:Rule
-  val rule: MockServerRule = MockServerRule()
+    private lateinit var dataSource: JacksonNewsNetworkDataSource
+    @get:Rule
+    val rule: MockServerRule = MockServerRule()
 
-  @Before
-  fun setup() {
-    dataSource = JacksonNewsNetworkDataSource(
-        rule.server.retrofitService(
-            JacksonNewsApiService::class.java,
-            JacksonConverterFactory.create()
+    @Before
+    fun setup() {
+        dataSource = JacksonNewsNetworkDataSource(
+                rule.server.retrofitService(
+                        JacksonNewsApiService::class.java,
+                        JacksonConverterFactory.create()
+                )
         )
-    )
-  }
+    }
 
-  @Test
-  fun sendsGetNews() {
-    rule.server.whenever(GET, "v2/top-headlines")
-        .thenRespond(success(jsonBody = fileBody("GetNews.json")))
+    @Test
+    fun sendsGetNews() {
+        rule.server.whenever(GET, "v2/top-headlines")
+                .thenRespond(success(jsonBody = fileBody("GetNews.json")))
 
-    runBlocking { dataSource.getNews() }
+        runBlocking { dataSource.getNews() }
 
-    rule.server.verify("v2/top-headlines").called(
-        times = once(),
-        queryParams = params(
-            "sources" to "crypto-coins-news",
-            "apiKey" to "a7c816f57c004c49a21bd458e11e2807"),
-        headers = headers(
-            "Cache-Control" to "max-age=640000"
-        ),
-        method = GET)
-  }
+        rule.server.verify("v2/top-headlines").called(
+                times = once(),
+                queryParams = params(
+                        "sources" to "crypto-coins-news",
+                        "apiKey" to "a7c816f57c004c49a21bd458e11e2807"),
+                headers = headers(
+                        "Cache-Control" to "max-age=640000"
+                ),
+                method = GET)
+    }
 
-  @Test
-  fun sendsPublishHeadline() {
-    rule.server.whenever(POST, "v2/top-headlines").thenRespond(success())
-    val article = anyArticle()
+    @Test
+    fun sendsPublishHeadline() {
+        rule.server.whenever(POST, "v2/top-headlines").thenRespond(success())
+        val article = anyArticle()
 
-    runBlocking { dataSource.publishHeadline(article) }
+        runBlocking { dataSource.publishHeadline(article) }
 
-    rule.server.verify("v2/top-headlines").called(
-        times = once(),
-        jsonBody = fileBody("PublishHeadline.json"),
-        method = POST)
-  }
+        rule.server.verify("v2/top-headlines").called(
+                times = once(),
+                jsonBody = fileBody("PublishHeadline.json"),
+                method = POST)
+    }
 
-  @Test
-  fun sendsPublishHeadlineUsingInlineBody() {
-    rule.server.whenever(POST, "v2/top-headlines").thenRespond(success())
-    val article = anyArticle()
+    @Test
+    fun sendsPublishHeadlineUsingInlineBody() {
+        rule.server.whenever(POST, "v2/top-headlines").thenRespond(success())
+        val article = anyArticle()
 
-    runBlocking { dataSource.publishHeadline(article) }
+        runBlocking { dataSource.publishHeadline(article) }
 
-    rule.server.verify("v2/top-headlines").called(
-        times = times(1),
-        jsonBody = inlineBody("{\n" +
-            "  \"title\": \"Any Title\",\n" +
-            "  \"description\": \"Any description\",\n" +
-            "  \"url\": \"http://any.url\",\n" +
-            "  \"urlToImage\": \"http://any.url/any_image.png\",\n" +
-            "  \"publishedAt\": \"2018-03-10T14:09:00Z\",\n" +
-            "  \"source\": {\n" +
-            "    \"id\": \"AnyId\",\n" +
-            "    \"name\": \"ANYID\"\n" +
-            "  }\n" +
-            "}\n"))
-  }
+        rule.server.verify("v2/top-headlines").called(
+                times = times(1),
+                jsonBody = inlineBody("{\n" +
+                        "  \"title\": \"Any Title\",\n" +
+                        "  \"description\": \"Any description\",\n" +
+                        "  \"url\": \"http://any.url\",\n" +
+                        "  \"urlToImage\": \"http://any.url/any_image.png\",\n" +
+                        "  \"publishedAt\": \"2018-03-10T14:09:00Z\",\n" +
+                        "  \"source\": {\n" +
+                        "    \"id\": \"AnyId\",\n" +
+                        "    \"name\": \"ANYID\"\n" +
+                        "  }\n" +
+                        "}\n"))
+    }
 
-  @Test
-  fun parsesNewsProperly() {
-    rule.server.whenever(GET, "v2/top-headlines")
-        .thenRespond(success(jsonBody = fileBody("GetNews.json")))
+    @Test
+    fun parsesNewsProperly() {
+        rule.server.whenever(GET, "v2/top-headlines")
+                .thenRespond(success(jsonBody = fileBody("GetNews.json")))
 
-    val news = runBlocking { dataSource.getNews() }
+        val news = runBlocking { dataSource.getNews() }
 
-    news eq expectedNews()
-  }
+        news eq expectedNews()
+    }
 
-  @Test(expected = IOException::class)
-  fun throwsIOExceptionOnGetNewsErrorResponse() {
-    rule.server.whenever(GET, "v2/top-headlines").thenRespond(error())
+    @Test(expected = IOException::class)
+    fun throwsIOExceptionOnGetNewsErrorResponse() {
+        rule.server.whenever(GET, "v2/top-headlines").thenRespond(error())
 
-    runBlocking { dataSource.getNews() }
-  }
+        runBlocking { dataSource.getNews() }
+    }
 
-  private fun expectedNews(): List<Article> {
-    return listOf(
-        Article(
-            "How to Get Android P's Screenshot Editing Tool on Any Android Phone",
-            "Last year, Apple brought advanced screenshot editing tools to the iPhone with iOS 11, and, this week, Google fired back with a similar Android feature called Markup. The only catch is that this new tool is limited to Android P, which launches later this year …",
-            "https://lifehacker.com/how-to-get-android-ps-screenshot-editing-tool-on-any-an-1823646122",
-            "https://i.kinja-img.com/gawker-media/image/upload/s--Y-5X_NcT--/c_fill,fl_progressive,g_center,h_450,q_80,w_800/nxmwbkwzoc1z1tmak7s4.jpg",
-            "2018-03-09T20:30:00Z",
-            Source(null, "Lifehacker.com")
-        ),
-        Article(
-            "Capital One's virtual credit cards could help you avoid fraud",
-            "Capital One is no stranger to trying new things -- especially when it comes to technology. Its Eno texting chatbot, for example, is a quick and conversational way for its customers to check their balances and perform simple tasks, like checking on recent tran…",
-            "https://www.engadget.com/2018/03/09/capital-one-virtual-credit-cards/",
-            "https://o.aolcdn.com/images/dims?thumbnail=1200%2C630&quality=80&image_uri=https%3A%2F%2Fo.aolcdn.com%2Fimages%2Fdims%3Fcrop%3D3861%252C2574%252C0%252C0%26quality%3D85%26format%3Djpg%26resize%3D1600%252C1067%26image_uri%3Dhttp%253A%252F%252Fo.aolcdn.com%252Fhss%252Fstorage%252Fmidas%252Fca9d74d8d57677d4f3291ae4347b26da%252F206197048%252Fcapital-one-financial-corp-signage-is-displayed-at-a-bank-branch-in-picture-id120933061%26client%3Da1acac3e1b3290917d92%26signature%3Db51d9958f8487452f6a8c6d354650fcb339f0520&client=cbc79c14efcebee57402&signature=44e59feb505c1b9c4e5867d453d3ed345010acac",
-            "2018-03-09T13:00:00Z",
-            Source("engadget", "Engadget")
-        ),
-        Article(
-            "Magic Leap gets \$461M more, Travis goes VC, and HQ Trivia scales up",
-            "Hello and welcome back to Equity, TechCrunch’s venture capital-focused podcast where we unpack the numbers behind the headlines. This week we had a corking set of news to get through, so we rounded up the usual gang (Matthew Lynley, Katie Roof, and myself), a…",
-            "http://techcrunch.com/2018/03/09/magic-leap-gets-461m-more-travis-goes-vc-and-hq-trivia-scales-up/",
-            "https://tctechcrunch2011.files.wordpress.com/2017/03/tc-equity-podcast-ios.jpg",
-            "2018-03-09T14:10:01Z",
-            Source("techcrunch", "TechCrunch")
+    private fun expectedNews(): List<Article> {
+        return listOf(
+                Article(
+                        "How to Get Android P's Screenshot Editing Tool on Any Android Phone",
+                        "Last year, Apple brought advanced screenshot editing tools to the iPhone with iOS 11, and, this week, Google fired back with a similar Android feature called Markup. The only catch is that this new tool is limited to Android P, which launches later this year …",
+                        "https://lifehacker.com/how-to-get-android-ps-screenshot-editing-tool-on-any-an-1823646122",
+                        "https://i.kinja-img.com/gawker-media/image/upload/s--Y-5X_NcT--/c_fill,fl_progressive,g_center,h_450,q_80,w_800/nxmwbkwzoc1z1tmak7s4.jpg",
+                        "2018-03-09T20:30:00Z",
+                        Source(null, "Lifehacker.com")
+                ),
+                Article(
+                        "Capital One's virtual credit cards could help you avoid fraud",
+                        "Capital One is no stranger to trying new things -- especially when it comes to technology. Its Eno texting chatbot, for example, is a quick and conversational way for its customers to check their balances and perform simple tasks, like checking on recent tran…",
+                        "https://www.engadget.com/2018/03/09/capital-one-virtual-credit-cards/",
+                        "https://o.aolcdn.com/images/dims?thumbnail=1200%2C630&quality=80&image_uri=https%3A%2F%2Fo.aolcdn.com%2Fimages%2Fdims%3Fcrop%3D3861%252C2574%252C0%252C0%26quality%3D85%26format%3Djpg%26resize%3D1600%252C1067%26image_uri%3Dhttp%253A%252F%252Fo.aolcdn.com%252Fhss%252Fstorage%252Fmidas%252Fca9d74d8d57677d4f3291ae4347b26da%252F206197048%252Fcapital-one-financial-corp-signage-is-displayed-at-a-bank-branch-in-picture-id120933061%26client%3Da1acac3e1b3290917d92%26signature%3Db51d9958f8487452f6a8c6d354650fcb339f0520&client=cbc79c14efcebee57402&signature=44e59feb505c1b9c4e5867d453d3ed345010acac",
+                        "2018-03-09T13:00:00Z",
+                        Source("engadget", "Engadget")
+                ),
+                Article(
+                        "Magic Leap gets \$461M more, Travis goes VC, and HQ Trivia scales up",
+                        "Hello and welcome back to Equity, TechCrunch’s venture capital-focused podcast where we unpack the numbers behind the headlines. This week we had a corking set of news to get through, so we rounded up the usual gang (Matthew Lynley, Katie Roof, and myself), a…",
+                        "http://techcrunch.com/2018/03/09/magic-leap-gets-461m-more-travis-goes-vc-and-hq-trivia-scales-up/",
+                        "https://tctechcrunch2011.files.wordpress.com/2017/03/tc-equity-podcast-ios.jpg",
+                        "2018-03-09T14:10:01Z",
+                        Source("techcrunch", "TechCrunch")
+                )
         )
-    )
-  }
+    }
 }

--- a/build.gradle
+++ b/build.gradle
@@ -1,5 +1,6 @@
 buildscript {
     ext.kotlin_version = '1.3.11'
+
     repositories {
         google()
         jcenter()

--- a/build.gradle
+++ b/build.gradle
@@ -6,7 +6,7 @@ buildscript {
         mavenCentral()
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:3.1.1'
+        classpath 'com.android.tools.build:gradle:3.2.1'
         classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:$kotlin_version"
     }
 }

--- a/build.gradle
+++ b/build.gradle
@@ -7,7 +7,7 @@ buildscript {
         mavenCentral()
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:3.2.1'
+        classpath 'com.android.tools.build:gradle:3.1.1'
         classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:$kotlin_version"
     }
 }

--- a/build.gradle
+++ b/build.gradle
@@ -1,5 +1,5 @@
 buildscript {
-    ext.kotlin_version = '1.2.31'
+    ext.kotlin_version = '1.3.11'
     repositories {
         google()
         jcenter()

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,8 +1,8 @@
 POM_NAME=Hiroaki
 POM_PACKAGING=aar
 POM_ARTIFACT_ID=hiroaki
-VERSION_NAME=0.0.9
-VERSION_CODE=9
+VERSION_NAME=0.1.0
+VERSION_CODE=10
 GROUP=me.jorgecastillo
 POM_DESCRIPTION=API integration test Kotlin extensions for Unit and Android tests.
 POM_URL=https://github.com/JorgeCastilloPrz/hiroaki.git

--- a/gradle.properties
+++ b/gradle.properties
@@ -14,3 +14,5 @@ POM_LICENCE_URL=http://www.apache.org/licenses/LICENSE-2.0.txt
 POM_LICENCE_DIST=repo
 POM_DEVELOPER_ID=jorgecastilloprz
 POM_DEVELOPER_NAME=JorgeCastillo
+android.useAndroidX=true
+android.enableJetifier=true

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,8 +1,8 @@
 POM_NAME=Hiroaki
 POM_PACKAGING=aar
 POM_ARTIFACT_ID=hiroaki
-VERSION_NAME=0.0.8
-VERSION_CODE=8
+VERSION_NAME=0.0.9
+VERSION_CODE=9
 GROUP=me.jorgecastillo
 POM_DESCRIPTION=API integration test Kotlin extensions for Unit and Android tests.
 POM_URL=https://github.com/JorgeCastilloPrz/hiroaki.git

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
-#Thu Jan 03 13:16:42 CET 2019
+#Fri Mar 09 14:47:05 CET 2018
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-4.6-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-4.4-all.zip

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
-#Fri Mar 09 14:47:05 CET 2018
+#Thu Jan 03 13:16:42 CET 2019
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-4.4-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-4.6-all.zip

--- a/hiroaki-android/build.gradle
+++ b/hiroaki-android/build.gradle
@@ -43,7 +43,7 @@ android {
 }
 
 dependencies {
-    api "me.jorgecastillo:hiroaki-core:0.0.8"
+    api "me.jorgecastillo:hiroaki-core:0.1.0"
 
     // linters
     ktlint "com.github.shyiko:ktlint:0.29.0"

--- a/hiroaki-android/build.gradle
+++ b/hiroaki-android/build.gradle
@@ -46,17 +46,17 @@ dependencies {
     api "me.jorgecastillo:hiroaki-core:0.0.8"
 
     // linters
-    ktlint "com.github.shyiko:ktlint:0.19.0"
+    ktlint "com.github.shyiko:ktlint:0.29.0"
 
     // Kotlin
     implementation "org.jetbrains.kotlin:kotlin-stdlib-jdk7:$kotlin_version"
     implementation "org.jetbrains.kotlin:kotlin-reflect:$kotlin_version"
 
     // Network
-    implementation 'com.squareup.okhttp3:okhttp:3.10.0'
+    implementation 'com.squareup.okhttp3:okhttp:3.12.0'
     implementation 'com.squareup.okhttp3:logging-interceptor:3.10.0'
-    implementation 'com.squareup.okhttp3:mockwebserver:3.10.0'
-    implementation 'com.android.support.test.espresso:espresso-core:3.0.1'
+    implementation 'com.squareup.okhttp3:mockwebserver:3.11.0'
+    implementation 'com.android.support.test.espresso:espresso-core:3.0.2'
 }
 
 apply from: '../ktlint/ktlint.gradle'

--- a/hiroaki-android/build.gradle
+++ b/hiroaki-android/build.gradle
@@ -3,10 +3,10 @@ apply plugin: 'kotlin-android'
 apply plugin: 'kotlin-android-extensions'
 
 android {
-    compileSdkVersion 27
+    compileSdkVersion 28
     defaultConfig {
         minSdkVersion 14
-        targetSdkVersion 27
+        targetSdkVersion 28
         testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"
 
         multiDexEnabled true

--- a/hiroaki-android/build.gradle
+++ b/hiroaki-android/build.gradle
@@ -7,7 +7,7 @@ android {
     defaultConfig {
         minSdkVersion 14
         targetSdkVersion 27
-        testInstrumentationRunner "android.support.test.runner.AndroidJUnitRunner"
+        testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"
 
         multiDexEnabled true
     }
@@ -57,6 +57,7 @@ dependencies {
     implementation 'com.squareup.okhttp3:logging-interceptor:3.10.0'
     implementation 'com.squareup.okhttp3:mockwebserver:3.11.0'
     androidTestImplementation 'androidx.test.espresso:espresso-core:3.1.1'
+    implementation 'androidx.test:monitor:1.1.1'
 }
 
 apply from: '../ktlint/ktlint.gradle'

--- a/hiroaki-android/build.gradle
+++ b/hiroaki-android/build.gradle
@@ -56,7 +56,7 @@ dependencies {
     implementation 'com.squareup.okhttp3:okhttp:3.12.0'
     implementation 'com.squareup.okhttp3:logging-interceptor:3.10.0'
     implementation 'com.squareup.okhttp3:mockwebserver:3.11.0'
-    implementation 'com.android.support.test.espresso:espresso-core:3.0.2'
+    androidTestImplementation 'androidx.test.espresso:espresso-core:3.1.1'
 }
 
 apply from: '../ktlint/ktlint.gradle'

--- a/hiroaki-android/gradle-mvn-push.gradle
+++ b/hiroaki-android/gradle-mvn-push.gradle
@@ -16,11 +16,11 @@ def getSnapshotRepositoryUrl() {
 }
 
 def getRepositoryUsername() {
-  return hasProperty('NEXUS_USERNAME') ? NEXUS_USERNAME : ""
+  return hasProperty('nexusUsername') ? nexusUsername : ""
 }
 
 def getRepositoryPassword() {
-  return hasProperty('NEXUS_PASSWORD') ? NEXUS_PASSWORD : ""
+  return hasProperty('nexusPassword') ? nexusPassword : ""
 }
 
 afterEvaluate { project ->

--- a/hiroaki-android/src/main/java/me/jorgecastillo/hiroaki/internal/AndroidMockServerRule.kt
+++ b/hiroaki-android/src/main/java/me/jorgecastillo/hiroaki/internal/AndroidMockServerRule.kt
@@ -12,20 +12,20 @@ import org.junit.rules.ExternalResource
  */
 class AndroidMockServerRule : ExternalResource() {
 
-  lateinit var server: MockWebServer
+    lateinit var server: MockWebServer
 
-  @Before
-  override fun before() {
-    server = MockWebServer()
-    AndroidDispatcherRetainer.androidContext = InstrumentationRegistry.getInstrumentation().context
-    AndroidDispatcherRetainer.registerRetainer()
-    AndroidDispatcherRetainer.resetDispatchers()
-    server.start()
-  }
+    @Before
+    override fun before() {
+        server = MockWebServer()
+        AndroidDispatcherRetainer.androidContext = InstrumentationRegistry.getInstrumentation().context
+        AndroidDispatcherRetainer.registerRetainer()
+        AndroidDispatcherRetainer.resetDispatchers()
+        server.start()
+    }
 
-  override fun after() {
-    server.shutdown()
-    AndroidDispatcherRetainer.resetDispatchers()
-    server.setDispatcher(AndroidDispatcherRetainer.queueDispatcher)
-  }
+    override fun after() {
+        server.shutdown()
+        AndroidDispatcherRetainer.resetDispatchers()
+        server.setDispatcher(AndroidDispatcherRetainer.queueDispatcher)
+    }
 }

--- a/hiroaki-android/src/main/java/me/jorgecastillo/hiroaki/internal/AndroidMockServerRule.kt
+++ b/hiroaki-android/src/main/java/me/jorgecastillo/hiroaki/internal/AndroidMockServerRule.kt
@@ -1,6 +1,6 @@
 package me.jorgecastillo.hiroaki.internal
 
-import android.support.test.InstrumentationRegistry
+import androidx.test.platform.app.InstrumentationRegistry
 import me.jorgecastillo.hiroaki.dispatcher.AndroidDispatcherRetainer
 import okhttp3.mockwebserver.MockWebServer
 import org.junit.Before
@@ -12,20 +12,20 @@ import org.junit.rules.ExternalResource
  */
 class AndroidMockServerRule : ExternalResource() {
 
-    lateinit var server: MockWebServer
+  lateinit var server: MockWebServer
 
-    @Before
-    override fun before() {
-        server = MockWebServer()
-        AndroidDispatcherRetainer.androidContext = InstrumentationRegistry.getContext()
-        AndroidDispatcherRetainer.registerRetainer()
-        AndroidDispatcherRetainer.resetDispatchers()
-        server.start()
-    }
+  @Before
+  override fun before() {
+    server = MockWebServer()
+    AndroidDispatcherRetainer.androidContext = InstrumentationRegistry.getInstrumentation().context
+    AndroidDispatcherRetainer.registerRetainer()
+    AndroidDispatcherRetainer.resetDispatchers()
+    server.start()
+  }
 
-    override fun after() {
-        server.shutdown()
-        AndroidDispatcherRetainer.resetDispatchers()
-        server.setDispatcher(AndroidDispatcherRetainer.queueDispatcher)
-    }
+  override fun after() {
+    server.shutdown()
+    AndroidDispatcherRetainer.resetDispatchers()
+    server.setDispatcher(AndroidDispatcherRetainer.queueDispatcher)
+  }
 }

--- a/hiroaki-android/src/main/java/me/jorgecastillo/hiroaki/internal/AndroidMockServerSuite.kt
+++ b/hiroaki-android/src/main/java/me/jorgecastillo/hiroaki/internal/AndroidMockServerSuite.kt
@@ -1,6 +1,6 @@
 package me.jorgecastillo.hiroaki.internal
 
-import android.support.test.InstrumentationRegistry
+import androidx.test.platform.app.InstrumentationRegistry
 import me.jorgecastillo.hiroaki.dispatcher.AndroidDispatcherRetainer
 import okhttp3.mockwebserver.MockWebServer
 import org.junit.After
@@ -11,21 +11,21 @@ import org.junit.Before
  * sets the android Context up into the library so it can easily reach asset resources for json body files.
  */
 open class AndroidMockServerSuite {
-    lateinit var server: MockWebServer
+  lateinit var server: MockWebServer
 
-    @Before
-    open fun setup() {
-        server = MockWebServer()
-        AndroidDispatcherRetainer.androidContext = InstrumentationRegistry.getContext()
-        AndroidDispatcherRetainer.registerRetainer()
-        AndroidDispatcherRetainer.resetDispatchers()
-        server.start()
-    }
+  @Before
+  open fun setup() {
+    server = MockWebServer()
+    AndroidDispatcherRetainer.androidContext = InstrumentationRegistry.getInstrumentation().context
+    AndroidDispatcherRetainer.registerRetainer()
+    AndroidDispatcherRetainer.resetDispatchers()
+    server.start()
+  }
 
-    @After
-    open fun tearDown() {
-        server.shutdown()
-        AndroidDispatcherRetainer.resetDispatchers()
-        server.setDispatcher(AndroidDispatcherRetainer.queueDispatcher)
-    }
+  @After
+  open fun tearDown() {
+    server.shutdown()
+    AndroidDispatcherRetainer.resetDispatchers()
+    server.setDispatcher(AndroidDispatcherRetainer.queueDispatcher)
+  }
 }

--- a/hiroaki-android/src/main/java/me/jorgecastillo/hiroaki/internal/AndroidMockServerSuite.kt
+++ b/hiroaki-android/src/main/java/me/jorgecastillo/hiroaki/internal/AndroidMockServerSuite.kt
@@ -11,21 +11,21 @@ import org.junit.Before
  * sets the android Context up into the library so it can easily reach asset resources for json body files.
  */
 open class AndroidMockServerSuite {
-  lateinit var server: MockWebServer
+    lateinit var server: MockWebServer
 
-  @Before
-  open fun setup() {
-    server = MockWebServer()
-    AndroidDispatcherRetainer.androidContext = InstrumentationRegistry.getInstrumentation().context
-    AndroidDispatcherRetainer.registerRetainer()
-    AndroidDispatcherRetainer.resetDispatchers()
-    server.start()
-  }
+    @Before
+    open fun setup() {
+        server = MockWebServer()
+        AndroidDispatcherRetainer.androidContext = InstrumentationRegistry.getInstrumentation().context
+        AndroidDispatcherRetainer.registerRetainer()
+        AndroidDispatcherRetainer.resetDispatchers()
+        server.start()
+    }
 
-  @After
-  open fun tearDown() {
-    server.shutdown()
-    AndroidDispatcherRetainer.resetDispatchers()
-    server.setDispatcher(AndroidDispatcherRetainer.queueDispatcher)
-  }
+    @After
+    open fun tearDown() {
+        server.shutdown()
+        AndroidDispatcherRetainer.resetDispatchers()
+        server.setDispatcher(AndroidDispatcherRetainer.queueDispatcher)
+    }
 }

--- a/hiroaki-core/build.gradle
+++ b/hiroaki-core/build.gradle
@@ -8,17 +8,17 @@ test {
 
 dependencies {
     // linters
-    ktlint "com.github.shyiko:ktlint:0.19.0"
+    ktlint "com.github.shyiko:ktlint:0.29.0"
 
     // Kotlin
     implementation "org.jetbrains.kotlin:kotlin-stdlib-jdk7:$kotlin_version"
     implementation "org.jetbrains.kotlin:kotlin-reflect:$kotlin_version"
 
     // Network
-    implementation 'com.squareup.okhttp3:okhttp:3.10.0'
+    implementation 'com.squareup.okhttp3:okhttp:3.12.0'
     implementation 'com.squareup.okhttp3:logging-interceptor:3.10.0'
-    implementation 'com.squareup.okhttp3:mockwebserver:3.10.0'
-    implementation 'com.squareup.retrofit2:retrofit:2.3.0'
+    implementation 'com.squareup.okhttp3:mockwebserver:3.11.0'
+    implementation 'com.squareup.retrofit2:retrofit:2.5.0'
     implementation 'com.google.code.gson:gson:2.8.2'
 }
 

--- a/hiroaki-core/gradle-mvn-push.gradle
+++ b/hiroaki-core/gradle-mvn-push.gradle
@@ -16,11 +16,11 @@ def getSnapshotRepositoryUrl() {
 }
 
 def getRepositoryUsername() {
-  return hasProperty('NEXUS_USERNAME') ? NEXUS_USERNAME : ""
+  return hasProperty('nexusUsername') ? nexusUsername : ""
 }
 
 def getRepositoryPassword() {
-  return hasProperty('NEXUS_PASSWORD') ? NEXUS_PASSWORD : ""
+  return hasProperty('nexusPassword') ? nexusPassword : ""
 }
 
 afterEvaluate { project ->


### PR DESCRIPTION
### :pushpin: References
**Issues:**
* Fixes #60 

### :tophat: What is the goal?

* Given the discussions on #60 I'm preparing `0.1.0` targeting AndroidX. I've discarded maintaining two versions (support vs androidx) for a while, given that people can still target 0.0.8 if they still need to.

### 💻 How is it being implemented?

* Upgraded all dependencies.
* Moved all `support` library dependencies to the corresponding `androidx` ones.
* Upgraded target api to `28` for android artifacts.
* Upgraded Kotlin to 1.3.11 and coroutines to 1.1.0.

### 📱 How to Test

* Let tests run.