### PR TITLE
Make rules and suites configurable.

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -43,8 +43,8 @@ dependencies {
 
     implementation 'androidx.multidex:multidex:2.0.1'
 
-    testImplementation "me.jorgecastillo:hiroaki-core:0.1.0"
-    androidTestImplementation "me.jorgecastillo:hiroaki-android:0.1.0"
+    testImplementation project(":hiroaki-core")
+    androidTestImplementation project(":hiroaki-android")
 
     // Kotlin
     implementation "org.jetbrains.kotlin:kotlin-stdlib-jdk7:$kotlin_version"

--- a/app/src/androidTest/java/me/jorgecastillo/hiroaki/AndroidRuleParametersTest.kt
+++ b/app/src/androidTest/java/me/jorgecastillo/hiroaki/AndroidRuleParametersTest.kt
@@ -1,0 +1,65 @@
+package me.jorgecastillo.hiroaki
+
+import kotlinx.coroutines.runBlocking
+import me.jorgecastillo.hiroaki.data.datasource.JacksonNewsNetworkDataSource
+import me.jorgecastillo.hiroaki.data.service.JacksonNewsApiService
+import me.jorgecastillo.hiroaki.internal.AndroidMockServerRule
+import me.jorgecastillo.hiroaki.models.fileBody
+import me.jorgecastillo.hiroaki.models.success
+import org.junit.Before
+import org.junit.Rule
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.junit.runners.Parameterized
+import org.junit.runners.Parameterized.Parameters
+import retrofit2.converter.jackson.JacksonConverterFactory
+import java.net.InetAddress
+
+@RunWith(Parameterized::class)
+class AndroidRuleParametersTest(inetAddress: InetAddress, port: Int) {
+
+    private lateinit var dataSource: JacksonNewsNetworkDataSource
+    @get:Rule
+    val rule: AndroidMockServerRule = AndroidMockServerRule(inetAddress, port)
+
+    @Before
+    fun setup() {
+        dataSource = JacksonNewsNetworkDataSource(
+            rule.server.retrofitService(
+                JacksonNewsApiService::class.java,
+                JacksonConverterFactory.create()
+            )
+        )
+    }
+
+    @Test
+    fun sendsGetNews() {
+        rule.server.whenever(Method.GET, "v2/top-headlines")
+            .thenRespond(success(jsonBody = fileBody("GetNews.json")))
+
+        runBlocking { dataSource.getNews() }
+
+        rule.server.verify("v2/top-headlines").called(
+            times = once(),
+            queryParams = params(
+                "sources" to "crypto-coins-news",
+                "apiKey" to "a7c816f57c004c49a21bd458e11e2807"
+            ),
+            headers = headers(
+                "Cache-Control" to "max-age=640000"
+            ),
+            method = Method.GET
+        )
+    }
+
+    companion object {
+        @JvmStatic
+        @Parameters(name = "inetAddress={0} port={1}")
+        fun parameters() = listOf(
+            arrayOf(InetAddress.getByName("localhost"), 0),
+            arrayOf(InetAddress.getByName("localhost"), 8888),
+            arrayOf(InetAddress.getByName("127.0.0.1"), 0),
+            arrayOf(InetAddress.getByName("127.0.0.1"), 9999)
+        )
+    }
+}

--- a/app/src/androidTest/java/me/jorgecastillo/hiroaki/AndroidSuiteParametersTest.kt
+++ b/app/src/androidTest/java/me/jorgecastillo/hiroaki/AndroidSuiteParametersTest.kt
@@ -1,0 +1,62 @@
+package me.jorgecastillo.hiroaki
+
+import kotlinx.coroutines.runBlocking
+import me.jorgecastillo.hiroaki.data.datasource.JacksonNewsNetworkDataSource
+import me.jorgecastillo.hiroaki.data.service.JacksonNewsApiService
+import me.jorgecastillo.hiroaki.internal.AndroidMockServerSuite
+import me.jorgecastillo.hiroaki.models.fileBody
+import me.jorgecastillo.hiroaki.models.success
+import org.junit.Before
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.junit.runners.Parameterized
+import org.junit.runners.Parameterized.Parameters
+import retrofit2.converter.jackson.JacksonConverterFactory
+import java.net.InetAddress
+
+@RunWith(Parameterized::class)
+class AndroidSuiteParametersTest(inetAddress: InetAddress, port: Int) : AndroidMockServerSuite(inetAddress, port) {
+
+    private lateinit var dataSource: JacksonNewsNetworkDataSource
+
+    @Before
+    fun setupDataSource() {
+        dataSource = JacksonNewsNetworkDataSource(
+            server.retrofitService(
+                JacksonNewsApiService::class.java,
+                JacksonConverterFactory.create()
+            )
+        )
+    }
+
+    @Test
+    fun sendsGetNews() {
+        server.whenever(Method.GET, "v2/top-headlines")
+            .thenRespond(success(jsonBody = fileBody("GetNews.json")))
+
+        runBlocking { dataSource.getNews() }
+
+        server.verify("v2/top-headlines").called(
+            times = once(),
+            queryParams = params(
+                "sources" to "crypto-coins-news",
+                "apiKey" to "a7c816f57c004c49a21bd458e11e2807"
+            ),
+            headers = headers(
+                "Cache-Control" to "max-age=640000"
+            ),
+            method = Method.GET
+        )
+    }
+
+    companion object {
+        @JvmStatic
+        @Parameters(name = "inetAddress={0} port={1}")
+        fun parameters() = listOf(
+            arrayOf(InetAddress.getByName("localhost"), 0),
+            arrayOf(InetAddress.getByName("localhost"), 8888),
+            arrayOf(InetAddress.getByName("127.0.0.1"), 0),
+            arrayOf(InetAddress.getByName("127.0.0.1"), 9999)
+        )
+    }
+}

--- a/app/src/test/java/me/jorgecastillo/hiroaki/RuleParametersTest.kt
+++ b/app/src/test/java/me/jorgecastillo/hiroaki/RuleParametersTest.kt
@@ -1,0 +1,65 @@
+package me.jorgecastillo.hiroaki
+
+import kotlinx.coroutines.runBlocking
+import me.jorgecastillo.hiroaki.data.datasource.JacksonNewsNetworkDataSource
+import me.jorgecastillo.hiroaki.data.service.JacksonNewsApiService
+import me.jorgecastillo.hiroaki.internal.MockServerRule
+import me.jorgecastillo.hiroaki.models.fileBody
+import me.jorgecastillo.hiroaki.models.success
+import org.junit.Before
+import org.junit.Rule
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.junit.runners.Parameterized
+import org.junit.runners.Parameterized.Parameters
+import retrofit2.converter.jackson.JacksonConverterFactory
+import java.net.InetAddress
+
+@RunWith(Parameterized::class)
+class RuleParametersTest(inetAddress: InetAddress, port: Int) {
+
+    private lateinit var dataSource: JacksonNewsNetworkDataSource
+    @get:Rule
+    val rule = MockServerRule(inetAddress, port)
+
+    @Before
+    fun setup() {
+        dataSource = JacksonNewsNetworkDataSource(
+            rule.server.retrofitService(
+                JacksonNewsApiService::class.java,
+                JacksonConverterFactory.create()
+            )
+        )
+    }
+
+    @Test
+    fun sendsGetNews() {
+        rule.server.whenever(Method.GET, "v2/top-headlines")
+            .thenRespond(success(jsonBody = fileBody("GetNews.json")))
+
+        runBlocking { dataSource.getNews() }
+
+        rule.server.verify("v2/top-headlines").called(
+            times = once(),
+            queryParams = params(
+                "sources" to "crypto-coins-news",
+                "apiKey" to "a7c816f57c004c49a21bd458e11e2807"
+            ),
+            headers = headers(
+                "Cache-Control" to "max-age=640000"
+            ),
+            method = Method.GET
+        )
+    }
+
+    companion object {
+        @JvmStatic
+        @Parameters(name = "inetAddress={0} port={1}")
+        fun parameters() = listOf(
+            arrayOf(InetAddress.getByName("localhost"), 0),
+            arrayOf(InetAddress.getByName("localhost"), 8888),
+            arrayOf(InetAddress.getByName("127.0.0.1"), 0),
+            arrayOf(InetAddress.getByName("127.0.0.1"), 9999)
+        )
+    }
+}

--- a/app/src/test/java/me/jorgecastillo/hiroaki/SuiteParametersTest.kt
+++ b/app/src/test/java/me/jorgecastillo/hiroaki/SuiteParametersTest.kt
@@ -1,0 +1,62 @@
+package me.jorgecastillo.hiroaki
+
+import kotlinx.coroutines.runBlocking
+import me.jorgecastillo.hiroaki.data.datasource.JacksonNewsNetworkDataSource
+import me.jorgecastillo.hiroaki.data.service.JacksonNewsApiService
+import me.jorgecastillo.hiroaki.internal.MockServerSuite
+import me.jorgecastillo.hiroaki.models.fileBody
+import me.jorgecastillo.hiroaki.models.success
+import org.junit.Before
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.junit.runners.Parameterized
+import org.junit.runners.Parameterized.Parameters
+import retrofit2.converter.jackson.JacksonConverterFactory
+import java.net.InetAddress
+
+@RunWith(Parameterized::class)
+class SuiteParametersTest(inetAddress: InetAddress, port: Int) : MockServerSuite(inetAddress, port) {
+
+    private lateinit var dataSource: JacksonNewsNetworkDataSource
+
+    @Before
+    fun setupDataSource() {
+        dataSource = JacksonNewsNetworkDataSource(
+            server.retrofitService(
+                JacksonNewsApiService::class.java,
+                JacksonConverterFactory.create()
+            )
+        )
+    }
+
+    @Test
+    fun sendsGetNews() {
+        server.whenever(Method.GET, "v2/top-headlines")
+            .thenRespond(success(jsonBody = fileBody("GetNews.json")))
+
+        runBlocking { dataSource.getNews() }
+
+        server.verify("v2/top-headlines").called(
+            times = once(),
+            queryParams = params(
+                "sources" to "crypto-coins-news",
+                "apiKey" to "a7c816f57c004c49a21bd458e11e2807"
+            ),
+            headers = headers(
+                "Cache-Control" to "max-age=640000"
+            ),
+            method = Method.GET
+        )
+    }
+
+    companion object {
+        @JvmStatic
+        @Parameters(name = "inetAddress={0} port={1}")
+        fun parameters() = listOf(
+            arrayOf(InetAddress.getByName("localhost"), 0),
+            arrayOf(InetAddress.getByName("localhost"), 8888),
+            arrayOf(InetAddress.getByName("127.0.0.1"), 0),
+            arrayOf(InetAddress.getByName("127.0.0.1"), 9999)
+        )
+    }
+}

--- a/hiroaki-android/build.gradle
+++ b/hiroaki-android/build.gradle
@@ -43,7 +43,7 @@ android {
 }
 
 dependencies {
-    api "me.jorgecastillo:hiroaki-core:0.1.0"
+    api project(":hiroaki-core")
 
     // linters
     ktlint "com.github.shyiko:ktlint:0.29.0"

--- a/hiroaki-android/src/main/java/me/jorgecastillo/hiroaki/internal/AndroidMockServerRule.kt
+++ b/hiroaki-android/src/main/java/me/jorgecastillo/hiroaki/internal/AndroidMockServerRule.kt
@@ -5,12 +5,16 @@ import me.jorgecastillo.hiroaki.dispatcher.AndroidDispatcherRetainer
 import okhttp3.mockwebserver.MockWebServer
 import org.junit.Before
 import org.junit.rules.ExternalResource
+import java.net.InetAddress
 
 /**
  * JUnit4 Rule to provide the mock server before and after the test execution. This is the Android version which also
  * sets the android Context up into the library so it can easily reach asset resources for json body files.
  */
-class AndroidMockServerRule : ExternalResource() {
+class AndroidMockServerRule @JvmOverloads constructor(
+    val inetAddress: InetAddress = InetAddress.getByName("localhost"),
+    val port: Int = 0
+) : ExternalResource() {
 
     lateinit var server: MockWebServer
 
@@ -20,7 +24,7 @@ class AndroidMockServerRule : ExternalResource() {
         AndroidDispatcherRetainer.androidContext = InstrumentationRegistry.getInstrumentation().context
         AndroidDispatcherRetainer.registerRetainer()
         AndroidDispatcherRetainer.resetDispatchers()
-        server.start()
+        server.start(inetAddress, port)
     }
 
     override fun after() {

--- a/hiroaki-android/src/main/java/me/jorgecastillo/hiroaki/internal/AndroidMockServerSuite.kt
+++ b/hiroaki-android/src/main/java/me/jorgecastillo/hiroaki/internal/AndroidMockServerSuite.kt
@@ -5,12 +5,16 @@ import me.jorgecastillo.hiroaki.dispatcher.AndroidDispatcherRetainer
 import okhttp3.mockwebserver.MockWebServer
 import org.junit.After
 import org.junit.Before
+import java.net.InetAddress
 
 /**
  * Base class to provide the mock server before and after the test execution. This is the Android version which also
  * sets the android Context up into the library so it can easily reach asset resources for json body files.
  */
-open class AndroidMockServerSuite {
+open class AndroidMockServerSuite @JvmOverloads constructor(
+    val inetAddress: InetAddress = InetAddress.getByName("localhost"),
+    val port: Int = 0
+) {
     lateinit var server: MockWebServer
 
     @Before
@@ -19,7 +23,7 @@ open class AndroidMockServerSuite {
         AndroidDispatcherRetainer.androidContext = InstrumentationRegistry.getInstrumentation().context
         AndroidDispatcherRetainer.registerRetainer()
         AndroidDispatcherRetainer.resetDispatchers()
-        server.start()
+        server.start(inetAddress, port)
     }
 
     @After

--- a/hiroaki-core/src/main/java/me/jorgecastillo/hiroaki/ServerExtensions.kt
+++ b/hiroaki-core/src/main/java/me/jorgecastillo/hiroaki/ServerExtensions.kt
@@ -28,7 +28,7 @@ fun <T> MockWebServer.retrofitService(
     converterFactory: Converter.Factory,
     okHttpClient: OkHttpClient = okHttpClient()
 ): T {
-    return Retrofit.Builder().baseUrl(this.url("/").toString())
+    return Retrofit.Builder().baseUrl(this.url("/"))
             .client(okHttpClient)
             .addConverterFactory(converterFactory).build()
             .create(serviceClass)

--- a/hiroaki-core/src/main/java/me/jorgecastillo/hiroaki/internal/MockServerRule.kt
+++ b/hiroaki-core/src/main/java/me/jorgecastillo/hiroaki/internal/MockServerRule.kt
@@ -4,8 +4,12 @@ import me.jorgecastillo.hiroaki.dispatcher.DispatcherRetainer
 import okhttp3.mockwebserver.MockWebServer
 import org.junit.Before
 import org.junit.rules.ExternalResource
+import java.net.InetAddress
 
-class MockServerRule : ExternalResource() {
+class MockServerRule @JvmOverloads constructor(
+    val inetAddress: InetAddress = InetAddress.getByName("localhost"),
+    val port: Int = 0
+) : ExternalResource() {
 
     lateinit var server: MockWebServer
 
@@ -14,7 +18,7 @@ class MockServerRule : ExternalResource() {
         server = MockWebServer()
         DispatcherRetainer.registerRetainer()
         DispatcherRetainer.resetDispatchers()
-        server.start()
+        server.start(inetAddress, port)
     }
 
     override fun after() {

--- a/hiroaki-core/src/main/java/me/jorgecastillo/hiroaki/internal/MockServerSuite.kt
+++ b/hiroaki-core/src/main/java/me/jorgecastillo/hiroaki/internal/MockServerSuite.kt
@@ -4,13 +4,17 @@ import me.jorgecastillo.hiroaki.dispatcher.DispatcherRetainer
 import okhttp3.mockwebserver.MockWebServer
 import org.junit.After
 import org.junit.Before
+import java.net.InetAddress
 
 /**
  * Base class to provide the mock server before and after the test execution. Intentionally avoided
  * using a rule for readability (not requiring tests to access server through the rule like
  * rule.server.enqueue() but directly server.enqueue()).
  */
-open class MockServerSuite {
+open class MockServerSuite @JvmOverloads constructor(
+    val inetAddress: InetAddress = InetAddress.getByName("localhost"),
+    val port: Int = 0
+) {
     lateinit var server: MockWebServer
 
     @Before
@@ -18,7 +22,7 @@ open class MockServerSuite {
         server = MockWebServer()
         DispatcherRetainer.registerRetainer()
         DispatcherRetainer.resetDispatchers()
-        server.start()
+        server.start(inetAddress, port)
     }
 
     @After


### PR DESCRIPTION
### :pushpin: References
**Issues:**
* Fixes #62 

### :tophat: What is the goal?

* With this PR it is now possible to configure Rules and Suites in the repo with custom inetAddress and port. 

### 💻 How is it being implemented?

Parameters put into constructor with default values and `JvmOverloads`. This will make it 100% backward compatible with Kotlin and Java clients.

Default values are the default ones OkHttp MockWebServer uses for years. `localhost` for the address and `0` for the port (which means a random port depending on https or http)

### 📱 How to Test

Current tests run successfully since it is backward compatible. Will add new tests for custom ports.
