### PR TITLE
Add a simplified version of `retrofitService` extension

### DIFF
--- a/app/src/androidTest/java/me/jorgecastillo/hiroaki/AndroidRuleParametersTest.kt
+++ b/app/src/androidTest/java/me/jorgecastillo/hiroaki/AndroidRuleParametersTest.kt
@@ -2,7 +2,6 @@ package me.jorgecastillo.hiroaki
 
 import kotlinx.coroutines.runBlocking
 import me.jorgecastillo.hiroaki.data.datasource.JacksonNewsNetworkDataSource
-import me.jorgecastillo.hiroaki.data.service.JacksonNewsApiService
 import me.jorgecastillo.hiroaki.internal.AndroidMockServerRule
 import me.jorgecastillo.hiroaki.models.fileBody
 import me.jorgecastillo.hiroaki.models.success
@@ -25,10 +24,7 @@ class AndroidRuleParametersTest(inetAddress: InetAddress, port: Int) {
     @Before
     fun setup() {
         dataSource = JacksonNewsNetworkDataSource(
-            rule.server.retrofitService(
-                JacksonNewsApiService::class.java,
-                JacksonConverterFactory.create()
-            )
+            rule.server.retrofitService(JacksonConverterFactory.create())
         )
     }
 

--- a/app/src/androidTest/java/me/jorgecastillo/hiroaki/AndroidSuiteParametersTest.kt
+++ b/app/src/androidTest/java/me/jorgecastillo/hiroaki/AndroidSuiteParametersTest.kt
@@ -2,7 +2,6 @@ package me.jorgecastillo.hiroaki
 
 import kotlinx.coroutines.runBlocking
 import me.jorgecastillo.hiroaki.data.datasource.JacksonNewsNetworkDataSource
-import me.jorgecastillo.hiroaki.data.service.JacksonNewsApiService
 import me.jorgecastillo.hiroaki.internal.AndroidMockServerSuite
 import me.jorgecastillo.hiroaki.models.fileBody
 import me.jorgecastillo.hiroaki.models.success
@@ -22,10 +21,7 @@ class AndroidSuiteParametersTest(inetAddress: InetAddress, port: Int) : AndroidM
     @Before
     fun setupDataSource() {
         dataSource = JacksonNewsNetworkDataSource(
-            server.retrofitService(
-                JacksonNewsApiService::class.java,
-                JacksonConverterFactory.create()
-            )
+            server.retrofitService(JacksonConverterFactory.create())
         )
     }
 

--- a/app/src/androidTest/java/me/jorgecastillo/hiroaki/AndroidVerificationTests.kt
+++ b/app/src/androidTest/java/me/jorgecastillo/hiroaki/AndroidVerificationTests.kt
@@ -4,7 +4,6 @@ import android.content.Intent
 import androidx.test.filters.LargeTest
 import androidx.test.rule.ActivityTestRule
 import androidx.test.runner.AndroidJUnit4
-import me.jorgecastillo.hiroaki.data.service.MoshiNewsApiService
 import me.jorgecastillo.hiroaki.internal.AndroidMockServerSuite
 import me.jorgecastillo.hiroaki.matchers.never
 import me.jorgecastillo.hiroaki.models.fileBody
@@ -26,11 +25,7 @@ class AndroidVerificationTests : AndroidMockServerSuite() {
     @Before
     override fun setup() {
         super.setup()
-        val mockService = server.retrofitService(
-            MoshiNewsApiService::class.java,
-            MoshiConverterFactory.create())
-        getApp()
-            .service = mockService
+        getApp().service = server.retrofitService(MoshiConverterFactory.create())
     }
 
     private fun startActivity(): MainActivity {

--- a/app/src/androidTest/java/me/jorgecastillo/hiroaki/ExampleInstrumentedTest.kt
+++ b/app/src/androidTest/java/me/jorgecastillo/hiroaki/ExampleInstrumentedTest.kt
@@ -10,7 +10,6 @@ import androidx.test.rule.ActivityTestRule
 import androidx.test.runner.AndroidJUnit4
 import kotlinx.coroutines.runBlocking
 import me.jorgecastillo.hiroaki.Method.GET
-import me.jorgecastillo.hiroaki.data.service.MoshiNewsApiService
 import me.jorgecastillo.hiroaki.internal.AndroidMockServerSuite
 import me.jorgecastillo.hiroaki.model.Article
 import me.jorgecastillo.hiroaki.model.Source
@@ -33,11 +32,7 @@ class ExampleInstrumentedTest : AndroidMockServerSuite() {
     @Before
     override fun setup() {
         super.setup()
-        val mockService = server.retrofitService(
-            MoshiNewsApiService::class.java,
-            MoshiConverterFactory.create())
-        getApp()
-            .service = mockService
+        getApp().service = server.retrofitService(MoshiConverterFactory.create())
     }
 
     private fun startActivity(): MainActivity {

--- a/app/src/androidTest/java/me/jorgecastillo/hiroaki/RuleAndroidVerificationTests.kt
+++ b/app/src/androidTest/java/me/jorgecastillo/hiroaki/RuleAndroidVerificationTests.kt
@@ -5,7 +5,6 @@ import androidx.test.filters.LargeTest
 import androidx.test.rule.ActivityTestRule
 import androidx.test.runner.AndroidJUnit4
 import kotlinx.coroutines.runBlocking
-import me.jorgecastillo.hiroaki.data.service.MoshiNewsApiService
 import me.jorgecastillo.hiroaki.internal.AndroidMockServerRule
 import me.jorgecastillo.hiroaki.matchers.never
 import me.jorgecastillo.hiroaki.models.fileBody
@@ -28,11 +27,7 @@ class RuleAndroidVerificationTests {
 
     @Before
     fun setup() {
-        val mockService = testRule.server.retrofitService(
-            MoshiNewsApiService::class.java,
-            MoshiConverterFactory.create())
-        getApp()
-            .service = mockService
+        getApp().service = testRule.server.retrofitService(MoshiConverterFactory.create())
     }
 
     private fun startActivity(): MainActivity {

--- a/app/src/androidTest/java/me/jorgecastillo/hiroaki/RuleExampleInstrumentedTest.kt
+++ b/app/src/androidTest/java/me/jorgecastillo/hiroaki/RuleExampleInstrumentedTest.kt
@@ -10,7 +10,6 @@ import androidx.test.rule.ActivityTestRule
 import androidx.test.runner.AndroidJUnit4
 import kotlinx.coroutines.runBlocking
 import me.jorgecastillo.hiroaki.Method.GET
-import me.jorgecastillo.hiroaki.data.service.MoshiNewsApiService
 import me.jorgecastillo.hiroaki.internal.AndroidMockServerRule
 import me.jorgecastillo.hiroaki.model.Article
 import me.jorgecastillo.hiroaki.model.Source
@@ -34,11 +33,7 @@ class RuleExampleInstrumentedTest {
 
     @Before
     fun setup() {
-        val mockService = testRule.server.retrofitService(
-            MoshiNewsApiService::class.java,
-            MoshiConverterFactory.create())
-        getApp()
-            .service = mockService
+        getApp().service = testRule.server.retrofitService(MoshiConverterFactory.create())
     }
 
     private fun startActivity(): MainActivity {

--- a/app/src/test/java/me/jorgecastillo/hiroaki/GsonNewsNetworkDataSourceTest.kt
+++ b/app/src/test/java/me/jorgecastillo/hiroaki/GsonNewsNetworkDataSourceTest.kt
@@ -4,7 +4,6 @@ import kotlinx.coroutines.runBlocking
 import me.jorgecastillo.hiroaki.Method.GET
 import me.jorgecastillo.hiroaki.Method.POST
 import me.jorgecastillo.hiroaki.data.datasource.GsonNewsNetworkDataSource
-import me.jorgecastillo.hiroaki.data.service.GsonNewsApiService
 import me.jorgecastillo.hiroaki.internal.MockServerSuite
 import me.jorgecastillo.hiroaki.matchers.times
 import me.jorgecastillo.hiroaki.model.Article
@@ -30,10 +29,7 @@ class GsonNewsNetworkDataSourceTest : MockServerSuite() {
     override fun setup() {
         super.setup()
         dataSource = GsonNewsNetworkDataSource(
-            server.retrofitService(
-                GsonNewsApiService::class.java,
-                GsonConverterFactory.create()
-            )
+            server.retrofitService(GsonConverterFactory.create())
         )
     }
 

--- a/app/src/test/java/me/jorgecastillo/hiroaki/JacksonNewsNetworkDataSourceTest.kt
+++ b/app/src/test/java/me/jorgecastillo/hiroaki/JacksonNewsNetworkDataSourceTest.kt
@@ -4,7 +4,6 @@ import kotlinx.coroutines.runBlocking
 import me.jorgecastillo.hiroaki.Method.GET
 import me.jorgecastillo.hiroaki.Method.POST
 import me.jorgecastillo.hiroaki.data.datasource.JacksonNewsNetworkDataSource
-import me.jorgecastillo.hiroaki.data.service.JacksonNewsApiService
 import me.jorgecastillo.hiroaki.internal.MockServerSuite
 import me.jorgecastillo.hiroaki.model.Article
 import me.jorgecastillo.hiroaki.model.Source
@@ -29,10 +28,7 @@ class JacksonNewsNetworkDataSourceTest : MockServerSuite() {
     override fun setup() {
         super.setup()
         dataSource = JacksonNewsNetworkDataSource(
-            server.retrofitService(
-                JacksonNewsApiService::class.java,
-                JacksonConverterFactory.create()
-            )
+            server.retrofitService(JacksonConverterFactory.create())
         )
     }
 

--- a/app/src/test/java/me/jorgecastillo/hiroaki/JsonDSLTest.kt
+++ b/app/src/test/java/me/jorgecastillo/hiroaki/JsonDSLTest.kt
@@ -24,10 +24,7 @@ class JsonDSLTest : MockServerSuite() {
     @Before
     override fun setup() {
         super.setup()
-        service = server.retrofitService(
-                SomeService::class.java,
-                GsonConverterFactory.create()
-        )
+        service = server.retrofitService(GsonConverterFactory.create())
     }
 
     @Test

--- a/app/src/test/java/me/jorgecastillo/hiroaki/MockingRequestsTest.kt
+++ b/app/src/test/java/me/jorgecastillo/hiroaki/MockingRequestsTest.kt
@@ -2,7 +2,6 @@ package me.jorgecastillo.hiroaki
 
 import kotlinx.coroutines.runBlocking
 import me.jorgecastillo.hiroaki.data.datasource.GsonNewsNetworkDataSource
-import me.jorgecastillo.hiroaki.data.service.GsonNewsApiService
 import me.jorgecastillo.hiroaki.internal.MockServerSuite
 import me.jorgecastillo.hiroaki.matchers.atLeast
 import me.jorgecastillo.hiroaki.matchers.atMost
@@ -32,10 +31,7 @@ class MockingRequestsTest : MockServerSuite() {
     override fun setup() {
         super.setup()
         dataSource = GsonNewsNetworkDataSource(
-                server.retrofitService(
-                        GsonNewsApiService::class.java,
-                        GsonConverterFactory.create()
-                )
+                server.retrofitService(GsonConverterFactory.create())
         )
     }
 

--- a/app/src/test/java/me/jorgecastillo/hiroaki/MoshiNewsNetworkDataSourceTest.kt
+++ b/app/src/test/java/me/jorgecastillo/hiroaki/MoshiNewsNetworkDataSourceTest.kt
@@ -4,7 +4,6 @@ import kotlinx.coroutines.runBlocking
 import me.jorgecastillo.hiroaki.Method.GET
 import me.jorgecastillo.hiroaki.Method.POST
 import me.jorgecastillo.hiroaki.data.datasource.MoshiNewsNetworkDataSource
-import me.jorgecastillo.hiroaki.data.service.MoshiNewsApiService
 import me.jorgecastillo.hiroaki.internal.MockServerSuite
 import me.jorgecastillo.hiroaki.model.Article
 import me.jorgecastillo.hiroaki.model.Source
@@ -31,10 +30,7 @@ class MoshiNewsNetworkDataSourceTest : MockServerSuite() {
     override fun setup() {
         super.setup()
         dataSource = MoshiNewsNetworkDataSource(
-            server.retrofitService(
-                MoshiNewsApiService::class.java,
-                MoshiConverterFactory.create()
-            )
+            server.retrofitService(MoshiConverterFactory.create())
         )
     }
 

--- a/app/src/test/java/me/jorgecastillo/hiroaki/RuleNetworkDataSourceTest.kt
+++ b/app/src/test/java/me/jorgecastillo/hiroaki/RuleNetworkDataSourceTest.kt
@@ -4,7 +4,6 @@ import kotlinx.coroutines.runBlocking
 import me.jorgecastillo.hiroaki.Method.GET
 import me.jorgecastillo.hiroaki.Method.POST
 import me.jorgecastillo.hiroaki.data.datasource.JacksonNewsNetworkDataSource
-import me.jorgecastillo.hiroaki.data.service.JacksonNewsApiService
 import me.jorgecastillo.hiroaki.internal.MockServerRule
 import me.jorgecastillo.hiroaki.matchers.times
 import me.jorgecastillo.hiroaki.model.Article
@@ -32,10 +31,7 @@ class RuleNetworkDataSourceTest {
     @Before
     fun setup() {
         dataSource = JacksonNewsNetworkDataSource(
-                rule.server.retrofitService(
-                        JacksonNewsApiService::class.java,
-                        JacksonConverterFactory.create()
-                )
+                rule.server.retrofitService(JacksonConverterFactory.create())
         )
     }
 

--- a/app/src/test/java/me/jorgecastillo/hiroaki/RuleParametersTest.kt
+++ b/app/src/test/java/me/jorgecastillo/hiroaki/RuleParametersTest.kt
@@ -2,7 +2,6 @@ package me.jorgecastillo.hiroaki
 
 import kotlinx.coroutines.runBlocking
 import me.jorgecastillo.hiroaki.data.datasource.JacksonNewsNetworkDataSource
-import me.jorgecastillo.hiroaki.data.service.JacksonNewsApiService
 import me.jorgecastillo.hiroaki.internal.MockServerRule
 import me.jorgecastillo.hiroaki.models.fileBody
 import me.jorgecastillo.hiroaki.models.success
@@ -25,10 +24,7 @@ class RuleParametersTest(inetAddress: InetAddress, port: Int) {
     @Before
     fun setup() {
         dataSource = JacksonNewsNetworkDataSource(
-            rule.server.retrofitService(
-                JacksonNewsApiService::class.java,
-                JacksonConverterFactory.create()
-            )
+            rule.server.retrofitService(JacksonConverterFactory.create())
         )
     }
 

--- a/app/src/test/java/me/jorgecastillo/hiroaki/SuiteParametersTest.kt
+++ b/app/src/test/java/me/jorgecastillo/hiroaki/SuiteParametersTest.kt
@@ -2,7 +2,6 @@ package me.jorgecastillo.hiroaki
 
 import kotlinx.coroutines.runBlocking
 import me.jorgecastillo.hiroaki.data.datasource.JacksonNewsNetworkDataSource
-import me.jorgecastillo.hiroaki.data.service.JacksonNewsApiService
 import me.jorgecastillo.hiroaki.internal.MockServerSuite
 import me.jorgecastillo.hiroaki.models.fileBody
 import me.jorgecastillo.hiroaki.models.success
@@ -22,10 +21,7 @@ class SuiteParametersTest(inetAddress: InetAddress, port: Int) : MockServerSuite
     @Before
     fun setupDataSource() {
         dataSource = JacksonNewsNetworkDataSource(
-            server.retrofitService(
-                JacksonNewsApiService::class.java,
-                JacksonConverterFactory.create()
-            )
+            server.retrofitService(JacksonConverterFactory.create())
         )
     }
 

--- a/app/src/test/java/me/jorgecastillo/hiroaki/VerificationTest.kt
+++ b/app/src/test/java/me/jorgecastillo/hiroaki/VerificationTest.kt
@@ -18,10 +18,7 @@ class VerificationTest : MockServerSuite() {
     @Before
     override fun setup() {
         super.setup()
-        service = server.retrofitService(
-                SomeService::class.java,
-                GsonConverterFactory.create()
-        )
+        service = server.retrofitService(GsonConverterFactory.create())
     }
 
     @Test

--- a/hiroaki-core/src/main/java/me/jorgecastillo/hiroaki/ServerExtensions.kt
+++ b/hiroaki-core/src/main/java/me/jorgecastillo/hiroaki/ServerExtensions.kt
@@ -23,15 +23,29 @@ private fun okHttpClient(
                 .addInterceptor(HttpLoggingInterceptor().setLevel(loggingLevel))
                 .build()
 
+inline fun <reified T> MockWebServer.retrofitService(
+    converterFactory: Converter.Factory? = null,
+    okHttpClient: OkHttpClient? = null
+): T = if (okHttpClient == null) {
+    retrofitService(T::class.java, converterFactory)
+} else {
+    retrofitService(T::class.java, converterFactory, okHttpClient)
+}
+
 fun <T> MockWebServer.retrofitService(
     serviceClass: Class<T>,
-    converterFactory: Converter.Factory,
+    converterFactory: Converter.Factory? = null,
     okHttpClient: OkHttpClient = okHttpClient()
 ): T {
     return Retrofit.Builder().baseUrl(this.url("/"))
             .client(okHttpClient)
-            .addConverterFactory(converterFactory).build()
+            .addOptionalConverterFactory(converterFactory)
+            .build()
             .create(serviceClass)
+}
+
+private fun Retrofit.Builder.addOptionalConverterFactory(converterFactory: Converter.Factory?) = apply {
+    converterFactory?.let { addConverterFactory(it) }
 }
 
 fun MockWebServer.whenever(


### PR DESCRIPTION
### :tophat: What is the goal?

Just realized that I can introduce a more simple version of `retrofitService` extension. This already simplified lots of tests in the repo. 

### 💻 How is it being implemented?

Introduce a reified inline version of `retrofitService` extension fun.

This makes it easier to configure test services since it will infer the type automagically without the need for providing `FooService::class.java`

Kept the old function as it was before. Should all be backward compatible.

Also made `converterFactory` parameter optional.
