### PR TITLE
Bump dependencies, bump library version

### DIFF
--- a/README.md
+++ b/README.md
@@ -171,7 +171,7 @@ These are all the supported params for `whenever` that you can match to. All of 
 server.whenever(method = Method.GET,
                 sentToPath = "v2/top-headlines",
                 queryParams = params("sources" to "crypto-coins-news",
-                        "apiKey" to "a7c816f57c004c49a21bd458e11e2807"),
+                        "apiKey" to "21a12ef352b649caa97499bed2e77350"),
                 jsonBody = fileBody("GetNews.json"), // (file, inline, or JsonDSL)
                 headers = headers("Cache-Control" to "max-age=640000"))
       .thenRespond(success(jsonFileName = "GetNews.json"))
@@ -271,7 +271,7 @@ fun verifiesCall() {
             headers = headers("Cache-Control" to "max-age=640000"),
             queryParams = params(
                                 "sources" to "crypto-coins-news",
-                                "apiKey" to "a7c816f57c004c49a21bd458e11e2807"),
+                                "apiKey" to "21a12ef352b649caa97499bed2e77350"),
             jsonBody = inlineBody("{\n" +
                                   "  \"title\": \"Any Title\",\n" +
                                   "  \"description\": \"Any description\",\n" +

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -44,8 +44,6 @@ kotlin {
 }
 
 dependencies {
-    def retrofitVersion = "2.5.0"
-
     implementation 'androidx.multidex:multidex:2.0.1'
 
     testImplementation project(":hiroaki-core")
@@ -69,10 +67,10 @@ dependencies {
     // Network
     implementation 'com.squareup.okhttp3:okhttp:3.13.1'
     implementation 'com.squareup.okhttp3:logging-interceptor:3.12.0'
-    implementation "com.squareup.retrofit2:retrofit:$retrofitVersion"
-    implementation "com.squareup.retrofit2:converter-moshi:$retrofitVersion"
-    implementation "com.squareup.retrofit2:converter-gson:$retrofitVersion"
-    implementation "com.squareup.retrofit2:converter-jackson:$retrofitVersion"
+    implementation "com.squareup.retrofit2:retrofit:$retrofit_version"
+    implementation "com.squareup.retrofit2:converter-moshi:$retrofit_version"
+    implementation "com.squareup.retrofit2:converter-gson:$retrofit_version"
+    implementation "com.squareup.retrofit2:converter-jackson:$retrofit_version"
     implementation 'com.squareup.moshi:moshi:1.8.0'
     implementation 'com.squareup.moshi:moshi-kotlin:1.8.0'
     implementation 'com.google.code.gson:gson:2.8.5'

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -30,6 +30,11 @@ android {
             }
         }
     }
+
+    compileOptions {
+        sourceCompatibility JavaVersion.VERSION_1_8
+        targetCompatibility JavaVersion.VERSION_1_8
+    }
 }
 
 kotlin {
@@ -47,7 +52,7 @@ dependencies {
     androidTestImplementation project(":hiroaki-android")
 
     // Kotlin
-    implementation "org.jetbrains.kotlin:kotlin-stdlib-jdk7:$kotlin_version"
+    implementation "org.jetbrains.kotlin:kotlin-stdlib-jdk8:$kotlin_version"
     implementation "org.jetbrains.kotlin:kotlin-reflect:$kotlin_version"
     implementation 'org.jetbrains.kotlinx:kotlinx-coroutines-core:1.3.2'
     implementation "org.jetbrains.kotlinx:kotlinx-coroutines-android:1.3.0"

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -3,11 +3,11 @@ apply plugin: 'kotlin-android'
 apply plugin: 'kotlin-android-extensions'
 
 android {
-    compileSdkVersion 28
+    compileSdkVersion 29
     defaultConfig {
         applicationId "me.jorgecastillo.hiroaki"
         minSdkVersion 14
-        targetSdkVersion 28
+        targetSdkVersion 29
         versionCode 1
         versionName "0.0.1"
         testInstrumentationRunner "me.jorgecastillo.hiroaki.CustomTestRunner"
@@ -49,12 +49,12 @@ dependencies {
     // Kotlin
     implementation "org.jetbrains.kotlin:kotlin-stdlib-jdk7:$kotlin_version"
     implementation "org.jetbrains.kotlin:kotlin-reflect:$kotlin_version"
-    implementation 'org.jetbrains.kotlinx:kotlinx-coroutines-core:1.1.0'
-    implementation "org.jetbrains.kotlinx:kotlinx-coroutines-android:1.1.0"
-    ktlint "com.github.shyiko:ktlint:0.29.0"
+    implementation 'org.jetbrains.kotlinx:kotlinx-coroutines-core:1.3.2'
+    implementation "org.jetbrains.kotlinx:kotlinx-coroutines-android:1.3.0"
+    ktlint "com.github.shyiko:ktlint:0.31.0"
 
     // UI
-    implementation "androidx.appcompat:appcompat:1.0.2"
+    implementation "androidx.appcompat:appcompat:1.1.0"
     implementation "androidx.cardview:cardview:1.0.0"
     implementation "androidx.recyclerview:recyclerview:1.0.0"
     implementation "com.google.android.material:material:1.0.0"
@@ -62,33 +62,33 @@ dependencies {
     implementation 'com.squareup.picasso:picasso:2.71828'
 
     // Network
-    implementation 'com.squareup.okhttp3:okhttp:3.12.0'
-    implementation 'com.squareup.okhttp3:logging-interceptor:3.10.0'
+    implementation 'com.squareup.okhttp3:okhttp:3.13.1'
+    implementation 'com.squareup.okhttp3:logging-interceptor:3.12.0'
     implementation "com.squareup.retrofit2:retrofit:$retrofitVersion"
     implementation "com.squareup.retrofit2:converter-moshi:$retrofitVersion"
     implementation "com.squareup.retrofit2:converter-gson:$retrofitVersion"
     implementation "com.squareup.retrofit2:converter-jackson:$retrofitVersion"
-    implementation 'com.squareup.moshi:moshi:1.5.0'
-    implementation 'com.squareup.moshi:moshi-kotlin:1.5.0'
-    implementation 'com.google.code.gson:gson:2.8.2'
+    implementation 'com.squareup.moshi:moshi:1.8.0'
+    implementation 'com.squareup.moshi:moshi-kotlin:1.8.0'
+    implementation 'com.google.code.gson:gson:2.8.5'
     implementation 'com.fasterxml.jackson.module:jackson-module-kotlin:2.9.4.1'
 
     // test
-    testImplementation 'com.squareup.okhttp3:mockwebserver:3.11.0'
-    androidTestImplementation 'com.squareup.okhttp3:mockwebserver:3.11.0'
+    testImplementation 'com.squareup.okhttp3:mockwebserver:3.13.1'
+    androidTestImplementation 'com.squareup.okhttp3:mockwebserver:3.13.1'
     testImplementation 'junit:junit:4.12'
-    testImplementation 'androidx.test:runner:1.1.1'
-    testImplementation 'org.mockito:mockito-core:2.19.0'
-    testImplementation 'org.mockito:mockito-android:2.19.0'
+    testImplementation 'androidx.test:runner:1.2.0'
+    testImplementation 'org.mockito:mockito-core:2.23.0'
+    testImplementation 'org.mockito:mockito-android:2.23.0'
     testImplementation "com.nhaarman:mockito-kotlin:1.5.0"
 
     androidTestImplementation 'junit:junit:4.12'
-    androidTestImplementation 'org.mockito:mockito-core:2.19.0'
-    androidTestImplementation 'org.mockito:mockito-android:2.19.0'
+    androidTestImplementation 'org.mockito:mockito-core:2.23.0'
+    androidTestImplementation 'org.mockito:mockito-android:2.23.0'
     androidTestImplementation "com.nhaarman:mockito-kotlin:1.5.0"
-    androidTestImplementation 'androidx.test.espresso:espresso-core:3.1.1'
-    androidTestImplementation'androidx.test.espresso:espresso-contrib:3.1.1'
-    androidTestImplementation 'androidx.test:rules:1.1.1'
+    androidTestImplementation 'androidx.test.espresso:espresso-core:3.2.0'
+    androidTestImplementation'androidx.test.espresso:espresso-contrib:3.2.0'
+    androidTestImplementation 'androidx.test:rules:1.2.0'
 }
 
 apply from: '../ktlint/ktlint.gradle'

--- a/app/src/androidTest/java/me/jorgecastillo/hiroaki/AndroidRuleParametersTest.kt
+++ b/app/src/androidTest/java/me/jorgecastillo/hiroaki/AndroidRuleParametersTest.kt
@@ -39,7 +39,7 @@ class AndroidRuleParametersTest(inetAddress: InetAddress, port: Int) {
             times = once(),
             queryParams = params(
                 "sources" to "crypto-coins-news",
-                "apiKey" to "a7c816f57c004c49a21bd458e11e2807"
+                "apiKey" to "21a12ef352b649caa97499bed2e77350"
             ),
             headers = headers(
                 "Cache-Control" to "max-age=640000"

--- a/app/src/androidTest/java/me/jorgecastillo/hiroaki/AndroidSuiteParametersTest.kt
+++ b/app/src/androidTest/java/me/jorgecastillo/hiroaki/AndroidSuiteParametersTest.kt
@@ -36,7 +36,7 @@ class AndroidSuiteParametersTest(inetAddress: InetAddress, port: Int) : AndroidM
             times = once(),
             queryParams = params(
                 "sources" to "crypto-coins-news",
-                "apiKey" to "a7c816f57c004c49a21bd458e11e2807"
+                "apiKey" to "21a12ef352b649caa97499bed2e77350"
             ),
             headers = headers(
                 "Cache-Control" to "max-age=640000"

--- a/app/src/androidTest/java/me/jorgecastillo/hiroaki/AndroidVerificationTests.kt
+++ b/app/src/androidTest/java/me/jorgecastillo/hiroaki/AndroidVerificationTests.kt
@@ -65,7 +65,7 @@ class AndroidVerificationTests : AndroidMockServerSuite() {
             times = once(),
             queryParams = params(
                 "sources" to "crypto-coins-news",
-                "apiKey" to "a7c816f57c004c49a21bd458e11e2807"))
+                "apiKey" to "21a12ef352b649caa97499bed2e77350"))
     }
 
     @Test

--- a/app/src/androidTest/java/me/jorgecastillo/hiroaki/RuleAndroidVerificationTests.kt
+++ b/app/src/androidTest/java/me/jorgecastillo/hiroaki/RuleAndroidVerificationTests.kt
@@ -67,7 +67,7 @@ class RuleAndroidVerificationTests {
             times = once(),
             queryParams = params(
                 "sources" to "crypto-coins-news",
-                "apiKey" to "a7c816f57c004c49a21bd458e11e2807"))
+                "apiKey" to "21a12ef352b649caa97499bed2e77350"))
     }
 
     @Test

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -10,10 +10,11 @@
         android:allowBackup="true"
         android:icon="@mipmap/ic_launcher"
         android:label="@string/app_name"
+        android:networkSecurityConfig="@xml/network_security_config"
         android:roundIcon="@mipmap/ic_launcher_round"
         android:supportsRtl="true"
         android:theme="@style/AppTheme"
-        tools:ignore="AllowBackup,GoogleAppIndexingWarning">
+        tools:ignore="AllowBackup,GoogleAppIndexingWarning,UnusedAttribute">
 
         <activity
             android:name="me.jorgecastillo.hiroaki.MainActivity"

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -1,8 +1,9 @@
 <?xml version="1.0" encoding="utf-8"?>
 <manifest xmlns:android="http://schemas.android.com/apk/res/android"
-          package="me.jorgecastillo.hiroaki">
+    xmlns:tools="http://schemas.android.com/tools"
+    package="me.jorgecastillo.hiroaki">
 
-    <uses-permission android:name="android.permission.INTERNET"/>
+    <uses-permission android:name="android.permission.INTERNET" />
 
     <application
         android:name="me.jorgecastillo.hiroaki.SampleApp"
@@ -11,15 +12,17 @@
         android:label="@string/app_name"
         android:roundIcon="@mipmap/ic_launcher_round"
         android:supportsRtl="true"
-        android:theme="@style/AppTheme">
+        android:theme="@style/AppTheme"
+        tools:ignore="AllowBackup,GoogleAppIndexingWarning">
+
         <activity
             android:name="me.jorgecastillo.hiroaki.MainActivity"
             android:label="@string/app_name"
             android:theme="@style/AppTheme.NoActionBar">
             <intent-filter>
-                <action android:name="android.intent.action.MAIN"/>
+                <action android:name="android.intent.action.MAIN" />
 
-                <category android:name="android.intent.category.LAUNCHER"/>
+                <category android:name="android.intent.category.LAUNCHER" />
             </intent-filter>
         </activity>
     </application>

--- a/app/src/main/java/me/jorgecastillo/hiroaki/data/service/GsonNewsApiService.kt
+++ b/app/src/main/java/me/jorgecastillo/hiroaki/data/service/GsonNewsApiService.kt
@@ -9,13 +9,13 @@ import retrofit2.http.Headers
 import retrofit2.http.POST
 
 interface GsonNewsApiService {
-    @GET("/v2/top-headlines?sources=crypto-coins-news&apiKey=a7c816f57c004c49a21bd458e11e2807")
+    @GET("/v2/top-headlines?sources=crypto-coins-news&apiKey=21a12ef352b649caa97499bed2e77350")
     @Headers("Cache-Control: max-age=640000")
     fun getNews(): Call<GsonNewsResponse>
 
     /**
      * This is a no-op method on the real news API, just created for testing purposes.
      */
-    @POST("/v2/top-headlines?apiKey=a7c816f57c004c49a21bd458e11e2807")
+    @POST("/v2/top-headlines?apiKey=21a12ef352b649caa97499bed2e77350")
     fun publishHeadline(@Body articleDto: GsonArticleDto): Call<Void>
 }

--- a/app/src/main/java/me/jorgecastillo/hiroaki/data/service/JacksonNewsApiService.kt
+++ b/app/src/main/java/me/jorgecastillo/hiroaki/data/service/JacksonNewsApiService.kt
@@ -9,13 +9,13 @@ import retrofit2.http.Headers
 import retrofit2.http.POST
 
 interface JacksonNewsApiService {
-    @GET("/v2/top-headlines?sources=crypto-coins-news&apiKey=a7c816f57c004c49a21bd458e11e2807")
+    @GET("/v2/top-headlines?sources=crypto-coins-news&apiKey=21a12ef352b649caa97499bed2e77350")
     @Headers("Cache-Control: max-age=640000")
     fun getNews(): Call<JacksonNewsResponse>
 
     /**
      * This is a no-op method on the real news API, just created for testing purposes.
      */
-    @POST("/v2/top-headlines?apiKey=a7c816f57c004c49a21bd458e11e2807")
+    @POST("/v2/top-headlines?apiKey=21a12ef352b649caa97499bed2e77350")
     fun publishHeadline(@Body articleDto: JacksonArticleDto): Call<Void>
 }

--- a/app/src/main/java/me/jorgecastillo/hiroaki/data/service/MoshiNewsApiService.kt
+++ b/app/src/main/java/me/jorgecastillo/hiroaki/data/service/MoshiNewsApiService.kt
@@ -9,13 +9,13 @@ import retrofit2.http.Headers
 import retrofit2.http.POST
 
 interface MoshiNewsApiService {
-    @GET("/v2/top-headlines?sources=crypto-coins-news&apiKey=a7c816f57c004c49a21bd458e11e2807")
+    @GET("/v2/top-headlines?sources=crypto-coins-news&apiKey=21a12ef352b649caa97499bed2e77350")
     @Headers("Cache-Control: max-age=640000")
     fun getNews(): Call<MoshiNewsResponse>
 
     /**
      * This is a no-op method on the real news API, just created for testing purposes.
      */
-    @POST("/v2/top-headlines?apiKey=a7c816f57c004c49a21bd458e11e2807")
+    @POST("/v2/top-headlines?apiKey=21a12ef352b649caa97499bed2e77350")
     fun publishHeadline(@Body articleDto: MoshiArticleDto): Call<Void>
 }

--- a/app/src/main/res/xml/network_security_config.xml
+++ b/app/src/main/res/xml/network_security_config.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="utf-8"?>
+<network-security-config>
+    <domain-config cleartextTrafficPermitted="true">
+        <domain includeSubdomains="true">localhost</domain>
+    </domain-config>
+</network-security-config>

--- a/app/src/test/java/me/jorgecastillo/hiroaki/GsonNewsNetworkDataSourceTest.kt
+++ b/app/src/test/java/me/jorgecastillo/hiroaki/GsonNewsNetworkDataSourceTest.kt
@@ -44,7 +44,7 @@ class GsonNewsNetworkDataSourceTest : MockServerSuite() {
             times = times(1),
             queryParams = params(
                 "sources" to "crypto-coins-news",
-                "apiKey" to "a7c816f57c004c49a21bd458e11e2807"),
+                "apiKey" to "21a12ef352b649caa97499bed2e77350"),
             headers = headers(
                 "Cache-Control" to "max-age=640000"
             ),

--- a/app/src/test/java/me/jorgecastillo/hiroaki/JacksonNewsNetworkDataSourceTest.kt
+++ b/app/src/test/java/me/jorgecastillo/hiroaki/JacksonNewsNetworkDataSourceTest.kt
@@ -43,7 +43,7 @@ class JacksonNewsNetworkDataSourceTest : MockServerSuite() {
             times = once(),
             queryParams = params(
                 "sources" to "crypto-coins-news",
-                "apiKey" to "a7c816f57c004c49a21bd458e11e2807"),
+                "apiKey" to "21a12ef352b649caa97499bed2e77350"),
             headers = headers(
                 "Cache-Control" to "max-age=640000"
             ),

--- a/app/src/test/java/me/jorgecastillo/hiroaki/MockingRequestsTest.kt
+++ b/app/src/test/java/me/jorgecastillo/hiroaki/MockingRequestsTest.kt
@@ -122,7 +122,7 @@ class MockingRequestsTest : MockServerSuite() {
                 method = Method.GET,
                 sentToPath = "v2/top-headlines",
                 queryParams = params("sources" to "crypto-coins-news",
-                        "apiKey" to "a7c816f57c004c49a21bd458e11e2807"))
+                        "apiKey" to "21a12ef352b649caa97499bed2e77350"))
                 .thenRespond(success(jsonBody = fileBody("GetNews.json")))
 
         val news = runBlocking { dataSource.getNews() }
@@ -157,7 +157,7 @@ class MockingRequestsTest : MockServerSuite() {
                 method = Method.GET,
                 queryParams = params(
                         "sources" to "crypto-coins-news",
-                        "apiKey" to "a7c816f57c004c49a21bd458e11e2807"),
+                        "apiKey" to "21a12ef352b649caa97499bed2e77350"),
                 headers = headers("Cache-Control" to "max-age=640000"))
     }
 

--- a/app/src/test/java/me/jorgecastillo/hiroaki/MoshiNewsNetworkDataSourceTest.kt
+++ b/app/src/test/java/me/jorgecastillo/hiroaki/MoshiNewsNetworkDataSourceTest.kt
@@ -45,7 +45,7 @@ class MoshiNewsNetworkDataSourceTest : MockServerSuite() {
             times = once(),
             queryParams = params(
                 "sources" to "crypto-coins-news",
-                "apiKey" to "a7c816f57c004c49a21bd458e11e2807"),
+                "apiKey" to "21a12ef352b649caa97499bed2e77350"),
             headers = headers(
                 "Cache-Control" to "max-age=640000"
             ),

--- a/app/src/test/java/me/jorgecastillo/hiroaki/RuleNetworkDataSourceTest.kt
+++ b/app/src/test/java/me/jorgecastillo/hiroaki/RuleNetworkDataSourceTest.kt
@@ -46,7 +46,7 @@ class RuleNetworkDataSourceTest {
                 times = once(),
                 queryParams = params(
                         "sources" to "crypto-coins-news",
-                        "apiKey" to "a7c816f57c004c49a21bd458e11e2807"),
+                        "apiKey" to "21a12ef352b649caa97499bed2e77350"),
                 headers = headers(
                         "Cache-Control" to "max-age=640000"
                 ),

--- a/app/src/test/java/me/jorgecastillo/hiroaki/RuleParametersTest.kt
+++ b/app/src/test/java/me/jorgecastillo/hiroaki/RuleParametersTest.kt
@@ -39,7 +39,7 @@ class RuleParametersTest(inetAddress: InetAddress, port: Int) {
             times = once(),
             queryParams = params(
                 "sources" to "crypto-coins-news",
-                "apiKey" to "a7c816f57c004c49a21bd458e11e2807"
+                "apiKey" to "21a12ef352b649caa97499bed2e77350"
             ),
             headers = headers(
                 "Cache-Control" to "max-age=640000"

--- a/app/src/test/java/me/jorgecastillo/hiroaki/SuiteParametersTest.kt
+++ b/app/src/test/java/me/jorgecastillo/hiroaki/SuiteParametersTest.kt
@@ -36,7 +36,7 @@ class SuiteParametersTest(inetAddress: InetAddress, port: Int) : MockServerSuite
             times = once(),
             queryParams = params(
                 "sources" to "crypto-coins-news",
-                "apiKey" to "a7c816f57c004c49a21bd458e11e2807"
+                "apiKey" to "21a12ef352b649caa97499bed2e77350"
             ),
             headers = headers(
                 "Cache-Control" to "max-age=640000"

--- a/build.gradle
+++ b/build.gradle
@@ -1,5 +1,5 @@
 buildscript {
-    ext.kotlin_version = '1.3.11'
+    ext.kotlin_version = '1.3.50'
 
     repositories {
         google()
@@ -7,7 +7,7 @@ buildscript {
         mavenCentral()
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:3.1.1'
+        classpath 'com.android.tools.build:gradle:3.5.2'
         classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:$kotlin_version"
     }
 }

--- a/build.gradle
+++ b/build.gradle
@@ -1,5 +1,6 @@
 buildscript {
     ext.kotlin_version = '1.3.50'
+    ext.retrofit_version = '2.6.2'
 
     repositories {
         google()

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,7 +1,7 @@
 POM_NAME=Hiroaki
 POM_PACKAGING=aar
 POM_ARTIFACT_ID=hiroaki
-VERSION_NAME=0.1.0
+VERSION_NAME=0.2.0
 VERSION_CODE=10
 GROUP=me.jorgecastillo
 POM_DESCRIPTION=API integration test Kotlin extensions for Unit and Android tests.

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
-#Fri Mar 09 14:47:05 CET 2018
+#Fri Nov 08 11:00:34 CET 2019
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-4.4-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-5.4.1-all.zip

--- a/hiroaki-android/build.gradle
+++ b/hiroaki-android/build.gradle
@@ -3,10 +3,10 @@ apply plugin: 'kotlin-android'
 apply plugin: 'kotlin-android-extensions'
 
 android {
-    compileSdkVersion 28
+    compileSdkVersion 29
     defaultConfig {
         minSdkVersion 14
-        targetSdkVersion 28
+        targetSdkVersion 29
         testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"
 
         multiDexEnabled true
@@ -46,18 +46,18 @@ dependencies {
     api project(":hiroaki-core")
 
     // linters
-    ktlint "com.github.shyiko:ktlint:0.29.0"
+    ktlint "com.github.shyiko:ktlint:0.31.0"
 
     // Kotlin
     implementation "org.jetbrains.kotlin:kotlin-stdlib-jdk7:$kotlin_version"
     implementation "org.jetbrains.kotlin:kotlin-reflect:$kotlin_version"
 
     // Network
-    implementation 'com.squareup.okhttp3:okhttp:3.12.0'
-    implementation 'com.squareup.okhttp3:logging-interceptor:3.10.0'
-    implementation 'com.squareup.okhttp3:mockwebserver:3.11.0'
-    androidTestImplementation 'androidx.test.espresso:espresso-core:3.1.1'
-    implementation 'androidx.test:monitor:1.1.1'
+    implementation 'com.squareup.okhttp3:okhttp:3.13.1'
+    implementation 'com.squareup.okhttp3:logging-interceptor:3.12.0'
+    implementation 'com.squareup.okhttp3:mockwebserver:3.13.1'
+    androidTestImplementation 'androidx.test.espresso:espresso-core:3.2.0'
+    implementation 'androidx.test:monitor:1.2.0'
 }
 
 apply from: '../ktlint/ktlint.gradle'

--- a/hiroaki-core/build.gradle
+++ b/hiroaki-core/build.gradle
@@ -18,7 +18,7 @@ dependencies {
     implementation 'com.squareup.okhttp3:okhttp:3.13.1'
     implementation 'com.squareup.okhttp3:logging-interceptor:3.12.0'
     implementation 'com.squareup.okhttp3:mockwebserver:3.13.1'
-    implementation 'com.squareup.retrofit2:retrofit:2.6.2'
+    implementation "com.squareup.retrofit2:retrofit:$retrofit_version"
     implementation 'com.google.code.gson:gson:2.8.5'
 }
 

--- a/hiroaki-core/build.gradle
+++ b/hiroaki-core/build.gradle
@@ -8,18 +8,18 @@ test {
 
 dependencies {
     // linters
-    ktlint "com.github.shyiko:ktlint:0.29.0"
+    ktlint "com.github.shyiko:ktlint:0.31.0"
 
     // Kotlin
     implementation "org.jetbrains.kotlin:kotlin-stdlib-jdk7:$kotlin_version"
     implementation "org.jetbrains.kotlin:kotlin-reflect:$kotlin_version"
 
     // Network
-    implementation 'com.squareup.okhttp3:okhttp:3.12.0'
-    implementation 'com.squareup.okhttp3:logging-interceptor:3.10.0'
-    implementation 'com.squareup.okhttp3:mockwebserver:3.11.0'
-    implementation 'com.squareup.retrofit2:retrofit:2.5.0'
-    implementation 'com.google.code.gson:gson:2.8.2'
+    implementation 'com.squareup.okhttp3:okhttp:3.13.1'
+    implementation 'com.squareup.okhttp3:logging-interceptor:3.12.0'
+    implementation 'com.squareup.okhttp3:mockwebserver:3.13.1'
+    implementation 'com.squareup.retrofit2:retrofit:2.6.2'
+    implementation 'com.google.code.gson:gson:2.8.5'
 }
 
 apply from: '../ktlint/ktlint.gradle'


### PR DESCRIPTION
### :tophat: What is the goal?

Some dependencies are quite old already and have been causing conflicts on client apps, like:
```
Cannot find a version of 'org.jetbrains.kotlinx:kotlinx-coroutines-core' that satisfies the version constraints: 
   Dependency path 'ArrowAndroidSamples:app:unspecified' --> 'org.jetbrains.kotlinx:kotlinx-coroutines-core:1.3.2'
   Constraint path 'ArrowAndroidSamples:app:unspecified' --> 'org.jetbrains.kotlinx:kotlinx-coroutines-core:{strictly 1.2.1}' because of the following reason: debugRuntimeClasspath uses version 1.2.1
   Dependency path 'ArrowAndroidSamples:app:unspecified' --> 'org.jetbrains.kotlinx:kotlinx-coroutines-core:1.2.1'
   Dependency path 'ArrowAndroidSamples:app:unspecified' --> 'org.jetbrains.kotlinx:kotlinx-coroutines-test:1.3.2' --> 'org.jetbrains.kotlinx:kotlinx-coroutines-core:1.3.2'
   Dependency path 'ArrowAndroidSamples:app:unspecified' --> 'org.jetbrains.kotlinx:kotlinx-coroutines-android:1.2.1' --> 'org.jetbrains.kotlinx:kotlinx-coroutines-core:1.2.1'
   Dependency path 'ArrowAndroidSamples:app:unspecified' --> 'org.jetbrains.kotlinx:kotlinx-coroutines-test:1.3.2' --> 'org.jetbrains.kotlinx:kotlinx-coroutines-debug:1.3.2' --> 'org.jetbrains.kotlinx:kotlinx-coroutines-core:1.3.2'
```
The goal is to bump everything to the latest stable version available.

### 💻 How is it being implemented?

* Bumped dependency versions.
* Bumped AGP to match latest AS and AGP stables (3.5.2).
* Bumped compile sdk to 29.
* Updated `app` module to compile targeting JDK8.
* Unified retrofit dependency version across modules.
* Fixed CLEAR_TEXT error in Android tests caused by bumping target SDK by whitelisting subdomains of localhost.
* Bumped Hiroaki version for a new release.

### 📱 How to Test

* Let CI run.