### PR TITLE
Added mocking forever support

### DIFF
--- a/app/src/test/java/me/jorgecastillo/hiroaki/MockForeverTests.kt
+++ b/app/src/test/java/me/jorgecastillo/hiroaki/MockForeverTests.kt
@@ -1,0 +1,122 @@
+package me.jorgecastillo.hiroaki
+
+import kotlinx.coroutines.runBlocking
+import me.jorgecastillo.hiroaki.data.datasource.GsonNewsNetworkDataSource
+import me.jorgecastillo.hiroaki.internal.MockServerSuite
+import me.jorgecastillo.hiroaki.matchers.times
+import me.jorgecastillo.hiroaki.models.error
+import me.jorgecastillo.hiroaki.models.fileBody
+import me.jorgecastillo.hiroaki.models.inlineBody
+import me.jorgecastillo.hiroaki.models.success
+import org.junit.Before
+import org.junit.Test
+import retrofit2.converter.gson.GsonConverterFactory
+import java.io.IOException
+
+class MockForeverTests : MockServerSuite() {
+
+    private lateinit var dataSource: GsonNewsNetworkDataSource
+
+    @Before
+    override fun setup() {
+        super.setup()
+        dataSource = GsonNewsNetworkDataSource(
+            server.retrofitService(GsonConverterFactory.create())
+        )
+    }
+
+    @Test
+    fun shouldRespondMultipleTimes() {
+        server.whenever(Method.GET, "v2/top-headlines")
+            .thenRespondForever(success(jsonBody = fileBody("GetNews.json")))
+
+        repeat(3) {
+            runBlocking { dataSource.getNews() }
+        }
+
+        server.verify("v2/top-headlines").called(times(count = 3))
+    }
+
+    @Test
+    fun shouldDispatchMultipleTimes() {
+        server.whenever(Method.GET, "v2/top-headlines")
+            .thenDispatchForever { request ->
+                success(
+                    jsonBody = inlineBody(
+                        """{
+                              "status": "ok",
+                              "totalResults": 2342,
+                              "articles": [
+                                {
+                                  "source": {
+                                    "id": ${request.path.length},
+                                    "name": "Lifehacker.com"
+                                  },
+                                  "author": "Jacob Kleinman",
+                                  "title": "How to Get Android P's Screenshot Editing Tool on Any Android Phone",
+                                  "description": "Last year, Apple brought advanced screenshot editing tools to the iPhone with iOS 11, and, this week, Google fired back with a similar Android feature called Markup. The only catch is that this new tool is limited to Android P, which launches later this year …",
+                                  "url": "https://lifehacker.com/how-to-get-android-ps-screenshot-editing-tool-on-any-an-1823646122",
+                                  "urlToImage": "https://i.kinja-img.com/gawker-media/image/upload/s--Y-5X_NcT--/c_fill,fl_progressive,g_center,h_450,q_80,w_800/nxmwbkwzoc1z1tmak7s4.jpg",
+                                  "publishedAt": "2018-03-09T20:30:00Z"
+                                }
+                              ]
+                            }
+                        """
+                    )
+                )
+            }
+
+        repeat(3) {
+            runBlocking { dataSource.getNews() }
+        }
+
+        server.verify("v2/top-headlines").called(times(count = 3))
+    }
+
+    @Test(expected = IOException::class)
+    fun regularResponseShouldOverrideRespondForever() {
+        server.whenever(Method.GET, "v2/top-headlines")
+            .thenRespond(error())
+            .thenRespondForever(success(jsonBody = fileBody("GetNews.json")))
+
+        runBlocking {
+            dataSource.getNews()
+        }
+
+        server.verify("v2/top-headlines").called()
+    }
+
+    @Test
+    fun secondResponseForeverShouldOverrideTheFirst() {
+        server.whenever(Method.GET, "v2/top-headlines")
+            .thenRespondForever(error())
+            .thenRespondForever(success(jsonBody = fileBody("GetNews.json")))
+
+        runBlocking {
+            dataSource.getNews()
+        }
+
+        server.verify("v2/top-headlines").called()
+    }
+
+    @Test
+    fun moreGenericMatcherShouldOverridePrevious() {
+        server.whenever(
+            method = Method.GET,
+            sentToPath = "v2/top-headlines",
+            queryParams = params(
+                "sources" to "crypto-coins-news",
+                "apiKey" to "21a12ef352b649caa97499bed2e77350"
+            )
+        ).thenRespondForever(error())
+
+        server.whenever(sentToPath = "v2/top-headlines")
+            .thenRespondForever(success(jsonBody = fileBody("GetNews.json")))
+
+        runBlocking {
+            dataSource.getNews()
+        }
+
+        server.verify("v2/top-headlines").called()
+    }
+}

--- a/hiroaki-core/src/main/java/me/jorgecastillo/hiroaki/models/PotentialRequestChain.kt
+++ b/hiroaki-core/src/main/java/me/jorgecastillo/hiroaki/models/PotentialRequestChain.kt
@@ -20,6 +20,15 @@ class PotentialRequestChain(private val matcher: Matcher<RecordedRequest>) {
     }
 
     /**
+     * Setup a mocked response that will be used forever until reset for the conditions given on the
+     * "whenever" statement.
+     */
+    fun thenRespondForever(mockResponse: MockResponse): PotentialRequestChain {
+        DispatcherRetainer.hiroakiDispatcher.addMockRequestForever(matcher, mockResponse)
+        return this
+    }
+
+    /**
      * Enqueue a dispatched response for the conditions given on the "whenever" statement. A
      * dispatched response is just a function that will receive the request and return the required
      * mocked response. This allows the user to configure returned responses depending on the
@@ -27,6 +36,17 @@ class PotentialRequestChain(private val matcher: Matcher<RecordedRequest>) {
      */
     fun thenDispatch(dispatchableBlock: (recordedRequest: RecordedRequest) -> MockResponse): PotentialRequestChain {
         DispatcherRetainer.hiroakiDispatcher.addDispatchableBlock(matcher, dispatchableBlock)
+        return this
+    }
+
+    /**
+     * Setup a dispatched response that will be used forever until reset for the conditions given on
+     * the "whenever" statement. A dispatched response is just a function that will receive the
+     * request and return the required mocked response. This allows the user to configure returned
+     * responses depending on the request.
+     */
+    fun thenDispatchForever(dispatchableBlock: (recordedRequest: RecordedRequest) -> MockResponse): PotentialRequestChain {
+        DispatcherRetainer.hiroakiDispatcher.addDispatchableBlockForever(matcher, dispatchableBlock)
         return this
     }
 }


### PR DESCRIPTION
### :pushpin: References
Fixes #68

### :tophat: What is the goal?

This PR adds 2 new functions `thenRespondForever` and `thenDispatchForever` to have a behavior where the mocking mechanism is persistent until the server is shut down.

### 💻 How is it being implemented?

In the original code, the requests list/queue is processed when new requests are executed. And earlier mocks are removed on-the-fly when hiroaki responds. It is actually not possible to compare and remove previous matchers immediately when they're added since they don't implement `equals` functionality.

With this approach here is some principles I put into place:

- Regular `respond` always takes priority regardless of being added before or after.
- The most recently added `respondForever` takes precedence. As mentioned above, I cannot clear previous matchers immediately when a new one is added. I could potentially clear previous one when a `respondForever` is matched successfully. I figured that this is not a good idea since 1. it is not trivial, 2. there might be cases where previously added matcher can be useful for other requests even though it is matched for one request.

### 📱 How to Test

Tests added testing various behavior. 
No changes to existing tests verify that we don't have any behavior change.
